### PR TITLE
[FIX] Separate WAR upload and deploy script execution

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,7 +136,16 @@ jobs:
           name: war-artifact
           path: build/libs/
 
-      - name: Deploy to EC2
+      - name: Upload WAR to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "build/libs/*.war"
+          target: "/home/${{ secrets.EC2_USERNAME }}/"
+
+      - name: Run deploy script on EC2
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -148,7 +157,5 @@ jobs:
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             export DB_NAME=${{ secrets.DB_NAME }}
             export SPRING_PROFILES_ACTIVE=prod
-            
-            sudo scp -i ${{ secrets.EC2_SSH_KEY }} build/libs/dondothat.war ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USERNAME }}/
             
             sudo /home/${{ secrets.EC2_USERNAME }}/deploy.sh


### PR DESCRIPTION
## 📌 관련 이슈
#3 

## ✨ 내용
 1. WAR 파일 업로드: appleboy/scp-action을 사용하여 빌드된 .war 파일을 GitHub Actions 러너에서 EC2 서버로 안전하게 전송합니다. 이 액션은 key 파라미터를 사용하여 인증을 처리합니다.
 2. 배포 스크립트 실행: appleboy/ssh-action을 사용하여 EC2 서버에 접속한 후, 환경 변수를 설정하고 deploy.sh 스크립트를 실행합니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
