### PR TITLE
[FIX] deploy시 deploy.sh 스크립트를 인스턴스로 함께 전송

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,13 +136,13 @@ jobs:
           name: war-artifact
           path: build/libs/
 
-      - name: Upload WAR to EC2
+      - name: Upload WAR and deploy.sh to EC2
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "build/libs/*.war"
+          source: "build/libs/*.war,deploy.sh"
           target: "/home/${{ secrets.EC2_USERNAME }}/"
 
       - name: Run deploy script on EC2
@@ -158,4 +158,5 @@ jobs:
             export DB_NAME=${{ secrets.DB_NAME }}
             export SPRING_PROFILES_ACTIVE=prod
             
+            chmod +x /home/${{ secrets.EC2_USERNAME }}/deploy.sh
             sudo /home/${{ secrets.EC2_USERNAME }}/deploy.sh

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,7 +136,16 @@ jobs:
           name: war-artifact
           path: build/libs/
 
-      - name: Deploy to EC2
+      - name: Upload WAR to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "build/libs/*.war"
+          target: "/home/${{ secrets.EC2_USERNAME }}/"
+
+      - name: Run deploy script on EC2
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -148,7 +157,5 @@ jobs:
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             export DB_NAME=${{ secrets.DB_NAME }}
             export SPRING_PROFILES_ACTIVE=prod
-            
-            sudo scp -i ${{ secrets.EC2_SSH_KEY }} build/libs/dondothat.war ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USERNAME }}/
             
             sudo /home/${{ secrets.EC2_USERNAME }}/deploy.sh


### PR DESCRIPTION
## 📌 관련 이슈
#3 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
1. `deploy.sh` 파일 전송: appleboy/scp-action을 사용하여 deploy.sh 스크립트도 EC2 인스턴스로 전송합니다.
2. 실행 권한 부여: appleboy/ssh-action에서 deploy.sh 스크립트에 실행 권한을 부여한 후 실행합니다.


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
