### PR TITLE
[BUG] WAR 파일명 불일치 문제

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,6 @@ TOMCAT_VERSION="9.0.89" # 사용할 톰캣 버전
 TOMCAT_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
 
 TOMCAT_HOME="/opt/tomcat"
-WAR_FILE="/home/${EC2_USERNAME}/dondothat.war"
 WEBAPPS_PATH="${TOMCAT_HOME}/webapps"
 
 echo "Starting deploy.sh script..."
@@ -92,7 +91,15 @@ sudo rm -f "${WEBAPPS_PATH}/dondothat.war"
 
 # 새로운 WAR 파일 복사
 echo "Copying new WAR file..."
-sudo mv "${WAR_FILE}" "${WEBAPPS_PATH}/"
+# /home/${EC2_USERNAME}/ 경로에서 *.war 파일을 찾아 이동
+UPLOADED_WAR=$(find /home/${EC2_USERNAME}/ -maxdepth 1 -name "*.war" -print -quit)
+
+if [ -z "$UPLOADED_WAR" ]; then
+    echo "Error: No WAR file found in /home/${EC2_USERNAME}/"
+    exit 1
+fi
+
+sudo mv "${UPLOADED_WAR}" "${WEBAPPS_PATH}/"
 
 # 톰캣 시작
 echo "Starting Tomcat..."


### PR DESCRIPTION
## 📌 관련 이슈
#3 

## ✨ 내용
deploy.sh 스크립트를 수정하여, 전송된 WAR 파일을 이름으로 특정하지 않고 와일드카드(`*.war`)를 사용하여 찾도록 변경.
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
