### PR TITLE
[FEAT] expense에 기능 추가

### DIFF
--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -14,4 +14,6 @@ public interface ExpenseMapper {
 	int update(ExpenseVO expense);
 
 	int delete(Long expenditureId);
+
+	List<ExpenseVO> getRecentExpenses(Long userId);
 }

--- a/src/main/java/org/bbagisix/expense/service/ExpenseService.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseService.java
@@ -2,6 +2,7 @@ package org.bbagisix.expense.service;
 
 import java.util.List;
 
+import org.bbagisix.expense.domain.ExpenseVO;
 import org.bbagisix.expense.dto.ExpenseDTO;
 
 public interface ExpenseService {
@@ -14,4 +15,8 @@ public interface ExpenseService {
 	ExpenseDTO updateExpense(Long expenditureId, ExpenseDTO expenseDTO);
 
 	void deleteExpense(Long expenditureId);
+
+	List<ExpenseVO> getRecentExpenses(Long userId);
+
+	ExpenseVO updateExpenseCategory(Long expenditureId, Long categoryId);
 }

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -62,6 +62,24 @@ public class ExpenseServiceImpl implements ExpenseService {
 		expenseMapper.delete(expenditureId);
 	}
 
+	@Override
+	public List<ExpenseVO> getRecentExpenses(Long userId) {
+		return expenseMapper.getRecentExpenses(userId);
+	}
+
+	@Override
+	public ExpenseVO updateExpenseCategory(Long expenditureId, Long categoryId) {
+		ExpenseVO vo = expenseMapper.findById(expenditureId);
+		if (vo == null) {
+			throw new RuntimeException("카테고리를 지정할 소비 내역이 없습니다. id=" + expenditureId);
+		}
+
+		vo.setCategoryId(categoryId);
+		expenseMapper.update(vo);
+
+		return vo;
+	}
+
 	private ExpenseVO dtoToVo(ExpenseDTO dto) {
 		if (dto == null)
 			return null;

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -55,4 +55,12 @@
         WHERE expenditure_id = #{expenditureId}
     </delete>
 
+    <select id="getRecentExpenses" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
+        SELECT *
+        FROM expenditure
+        WHERE user_id = #{userId}
+          AND expenditure_date >= DATE_SUB(CURDATE(), INTERVAL 3 MONTH)
+        ORDER BY expenditure_date DESC
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#70 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
expense에 최근 3개월 소비내역을 조회하는 기능과 카테고리 업데이트하는 기능을 추가했다..
테스트코드도 추가햇다.
service에서 update를 기존것을 사용하지 않고 굳이 새로 만든 이유는 
llm server에서 dto가 아닌 vo 형태로 받게끔되어있어서 classify service에서 vo로 전달해줄 예정인데
기존 update를 사용할 시 classify쪽에서 변환 과정이 많이일어나 코드가 복잡해질거같아서 그냥 새로 만들었다. 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
