### PR TITLE
[FEAT] 소비내역 분석 (과소비분석)

### DIFF
--- a/llm-server/server.py
+++ b/llm-server/server.py
@@ -4,6 +4,7 @@ from openai import OpenAI
 import asyncio
 from dotenv import load_dotenv
 from typing import List
+from datetime import datetime
 import os
 
 load_dotenv()
@@ -17,9 +18,13 @@ class Expenditure(BaseModel):
     asset_id: int
     amount: int
     description: str
-    expenditure_date: str
-    created_at: str
-    updated_at: str
+    expenditure_date: datetime
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        alias_generator = lambda s: ''.join(['_'+c.lower() if c.isupper() else c for c in s]).lstrip('_')
+        allow_population_by_field_name = True
 
 class ExpenditureBatch(BaseModel):
     exps:List[Expenditure]
@@ -71,7 +76,7 @@ async def analysis(batch: ExpenditureBatch):
     1. 전체 소비 중 비율이 높은 카테고리.
     2. 카페/간식(1), 편의점(2), 배달음식(4), 택시(5), 쇼핑(6), 술/유흥(7), 문화(8) 등 사치성 소비에 가중치를 둠.
     3. 절대 지출 금액이 높을 경우 우선 고려.
-    설명 없이 과소비 카테고리 번호만 쉼표로 구분하여 출력하세요.
+    설명 없이 과소비 카테고리 번호만 쉼표로 구분하여 출력하세요. 
     '''
     response = client.chat.completions.create(
         model="gpt-4o",

--- a/src/main/java/org/bbagisix/analytics/service/AnalyticsService.java
+++ b/src/main/java/org/bbagisix/analytics/service/AnalyticsService.java
@@ -1,4 +1,9 @@
 package org.bbagisix.analytics.service;
 
-public class AnalyticsService {
+import java.util.List;
+
+import org.bbagisix.category.dto.CategoryDTO;
+
+public interface AnalyticsService {
+	List<CategoryDTO> getTopCategories(Long userId);
 }

--- a/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
+++ b/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
@@ -1,0 +1,66 @@
+package org.bbagisix.analytics.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.bbagisix.category.dto.CategoryDTO;
+import org.bbagisix.category.service.CategoryService;
+import org.bbagisix.exception.BusinessException;
+import org.bbagisix.exception.ErrorCode;
+import org.bbagisix.expense.domain.ExpenseVO;
+import org.bbagisix.expense.service.ExpenseService;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsServiceImpl implements AnalyticsService {
+
+	private final ExpenseService expenseService;
+	private final CategoryService categoryService;
+	private final RestTemplate restTemplate = new RestTemplate();
+	private static final String URL = "http://llm-server:8000/analysis";
+	private static final String LOCAL_URL = "http://localhost:8000/analysis"; // 로컬 테스트용
+
+	@Override
+	public List<CategoryDTO> getTopCategories(Long userId) {
+
+		try {
+			List<ExpenseVO> expenses = expenseService.getRecentExpenses(userId);
+
+			Map<String, Object> payload = Map.of("exps", expenses);
+
+			Map<String, Object> response = restTemplate.postForObject(URL, payload, Map.class);
+			if (response == null || !response.containsKey("results")) {
+				throw new BusinessException(ErrorCode.LLM_ANALYTICS_ERROR);
+			}
+
+			List<Number> resultsRaw = (List<Number>)response.get("results");
+			List<Long> results = resultsRaw.stream()
+				.map(Number::longValue)
+				.toList();
+
+			List<CategoryDTO> categories = new ArrayList<>();
+			for (Long id : results) {
+				CategoryDTO dto = categoryService.getCategoryById(id);
+				if (dto != null) {
+					categories.add(dto);
+				}
+			}
+			return categories;
+
+		} catch (BusinessException e) {
+			log.warn("비즈니스 예외 발생: code={}, message={}", e.getCode(), e.getMessage());
+			throw e;
+		} catch (Exception e) {
+			log.error("메시지 저장 중 예상하지 못한 오류: ", e);
+			throw new BusinessException(ErrorCode.DATA_ACCESS_ERROR, e);
+		}
+
+	}
+}

--- a/src/main/java/org/bbagisix/exception/ErrorCode.java
+++ b/src/main/java/org/bbagisix/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
 	USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "U002", "사용자 ID는 필수입니다."),
 	USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "U003", "권한이 없습니다."),
-	
+
 	// 챌린지 관련 에러
 	CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CH001", "챌린지를 찾을 수 없습니다."),
 	CHALLENGE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CH002", "챌린지 ID는 필수입니다."),
@@ -35,6 +35,10 @@ public enum ErrorCode {
 	WEBSOCKET_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "W001", "채팅 연결에 실패했습니다."),
 	WEBSOCKET_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W002", "메시지 전송에 실패했습니다."),
 	SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "W003", "세션이 만료되었습니다. 다시 연결해주세요."),
+
+	// LLM 관련 에러
+	LLM_CLASSIFY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "L001", "카테고리 분류에 실패했습니다."),
+	LLM_ANALYTICS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "L002", "과소비 카테고리 분석에 실패했습니다."),
 
 	// 일반적인 시스템 에러
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/org/bbagisix/expense/domain/ExpenseVO.java
+++ b/src/main/java/org/bbagisix/expense/domain/ExpenseVO.java
@@ -2,6 +2,9 @@ package org.bbagisix.expense.domain;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +18,7 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ExpenseVO {
 	private Long expenditureId;
 	private Long userId;

--- a/src/test/java/org/bbagisix/analytics/service/AnalyticsServiceTest.java
+++ b/src/test/java/org/bbagisix/analytics/service/AnalyticsServiceTest.java
@@ -1,0 +1,60 @@
+package org.bbagisix.analytics.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.bbagisix.category.dto.CategoryDTO;
+import org.bbagisix.config.TestRootConfig;
+import org.bbagisix.expense.dto.ExpenseDTO;
+import org.bbagisix.expense.service.ExpenseService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.log4j.Log4j2;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TestRootConfig.class})
+@Transactional
+@Log4j2
+class AnalyticsServiceTest {
+
+	@Autowired
+	private AnalyticsService analyticsService;
+
+	@Autowired
+	private ExpenseService expenseService;
+
+	private ExpenseDTO createTestDTO(Long categoryId, Long amount) {
+		return ExpenseDTO.builder()
+			.userId(1L)
+			.categoryId(categoryId)
+			.assetId(1L)
+			.amount(amount)
+			.description("test description")
+			.expenditureDate(new java.util.Date())
+			.build();
+	}
+
+	@Test
+	void getTopCategories() {
+
+		// given
+		for (int i = 1; i < 9; i++) {
+			Long amount = 10000L * i;
+			expenseService.createExpense(createTestDTO((long)i, amount));
+			// 카테고리 1=10000원, 2=20000원, 3=30000원, ... 식의 테스트 데이터 생성
+		}
+
+		// when
+		List<CategoryDTO> topCategories = analyticsService.getTopCategories(1L);
+
+		// then
+		assertEquals(3, topCategories.size()); // 전체 결과 개수가 3개인지 확인
+		log.info(topCategories); // 결과 출력
+	}
+}

--- a/src/test/java/org/bbagisix/config/TestRootConfig.java
+++ b/src/test/java/org/bbagisix/config/TestRootConfig.java
@@ -1,7 +1,9 @@
 package org.bbagisix.config;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.sql.DataSource;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.logging.log4j.LogManager;
@@ -19,10 +21,8 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
-import javax.sql.DataSource;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @PropertySource({"classpath:/application-test.properties"})
@@ -30,8 +30,9 @@ import java.util.regex.Pattern;
 @ComponentScan(
 	basePackages = {
 		"org.bbagisix.expense",
-		"org.bbagisix.category", 
-		"org.bbagisix.user"
+		"org.bbagisix.category",
+		"org.bbagisix.user",
+		"org.bbagisix.analytics"
 	},
 	excludeFilters = {
 		@ComponentScan.Filter(type = org.springframework.context.annotation.FilterType.ANNOTATION, classes = {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#72 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 유저의 최근 3개월간 소비내역을 바탕으로 과소비 상위 3개 카테고리를 반환
- llm 서버 실행을 local에서 진행했기 때문에 도커 컨테이너 환경에서도 잘 작동될지는 미지수, (일단 로컬 테스트는 잘 됨)

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
