### PR TITLE
[REFACTOR] 채팅 응답 구조 변경

### DIFF
--- a/src/main/java/org/bbagisix/chat/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/org/bbagisix/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,0 +1,14 @@
+package org.bbagisix.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatRoomInfoResponse {
+
+	private final Long challengeId;
+	private final String challengeName;
+	private final Integer participantCount;
+	private final String status;
+}

--- a/src/main/java/org/bbagisix/chat/dto/response/ParticipantCountResponse.java
+++ b/src/main/java/org/bbagisix/chat/dto/response/ParticipantCountResponse.java
@@ -1,0 +1,12 @@
+package org.bbagisix.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantCountResponse {
+
+	private final Long challengeId;
+	private final Integer participantCount;
+}

--- a/src/main/java/org/bbagisix/chat/dto/response/ParticipantResponse.java
+++ b/src/main/java/org/bbagisix/chat/dto/response/ParticipantResponse.java
@@ -1,0 +1,16 @@
+package org.bbagisix.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantResponse {
+
+	private final Long userId;
+	private final String userName;
+	private final LocalDateTime joinedAt;
+	private final Boolean isActive;
+}

--- a/src/main/java/org/bbagisix/chat/dto/response/UserChatRoomResponse.java
+++ b/src/main/java/org/bbagisix/chat/dto/response/UserChatRoomResponse.java
@@ -1,0 +1,15 @@
+package org.bbagisix.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserChatRoomResponse {
+
+	private final Long userId;
+	private final Long challengeId;
+	private final String challengeName;
+	private final String status;
+	private final String message;
+}

--- a/src/main/java/org/bbagisix/chat/service/ChatSessionService.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatSessionService.java
@@ -26,7 +26,7 @@ public class ChatSessionService {
 		challengeParticipantCount.merge(challengeId, 1, Integer::sum);
 		int currentCount = challengeParticipantCount.get(challengeId);
 
-		log.info("챌린지 {} 접속사 증가: {} 명", challengeId, currentCount);
+		log.info("챌린지 {} 접속자 증가: {} 명", challengeId, currentCount);
 
 		// 접속자 수 변경을 모든 클라이언트에게 브로드캐스트
 		broadcastParticipantCount(challengeId, currentCount);
@@ -36,14 +36,14 @@ public class ChatSessionService {
 	 * 사용자 퇴장 - 접속자 수 감소
 	 */
 	public void removeParticipant(Long challengeId) {
-		challengeParticipantCount.computeIfPresent(challengeId, (key, count) -> {
-			int newCount = Math.max(0, count - 1);
+		challengeParticipantCount.computeIfPresent(challengeId, (key, count) -> {    // challengeId가 존재할 때만 실행
+			int newCount = Math.max(0, count - 1);    // 음수 방지 (비정상적 퇴장 방지)
 			log.info("챌린지 {} 접속자 감소: {} 명", challengeId, newCount);
 
 			// 접속자 수 변경을 모든 클라이언트에게 브로드캐스트
 			broadcastParticipantCount(challengeId, newCount);
 
-			return newCount == 0 ? null : newCount;        // 0이면 맵에서 제거
+			return newCount == 0 ? null : newCount;        // 0이면 맵에서 제거 -> 메모리 효율성
 		});
 	}
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #80 

## ✨ 내용
기존에는 채팅 응답을 `Map<String, Object>`로 받고 있었음 -> 가독성 및 유지보수 문제 발생
타입 안정성과 코드 가독성 향상을 위해 Response DTO로 변경
JSON 응답 구조는 기존과 동일
WebSocket 메시지는 기존 `ChatMessageDTO` 구조 유지함

주요 변경사항
1. Response DTO 4개 신규 생성
- `ChatRoomInfoResponse`: 채팅방 정보 응답
- `UserChatRoomResponse`: 사용자 현재 채팅방 응답
- `ParticipantResponse`: 참여자 정보 응답
- `ParticipantCountResponse`: 접속자 수 응답
2. ChatController API 메서드 4개 개선
- `getUserCurrentChatRoom()`: `Map` → `UserChatRoomResponse`
- `getChatRoomInfo()`: `Map` → `ChatRoomInfoResponse`
- `getParticipants()`: `List<Map>` → `List<ParticipantResponse>`
- `getParticipantCount()`: `Map` → `ParticipantCountResponse`
3. 안전한 타입 변환 유틸리티 추가
- `getLongFromMap()`, `getStringFromMap()` 등 null-safe 변환 메서드

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
