### PR TITLE
[FEAT] 채팅 서비스 Redis pub/sub 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     // Jackson
 //    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // Database
     implementation 'com.mysql:mysql-connector-j:8.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:6.0.13.Final'
     implementation 'org.glassfish:javax.el:3.0.1-b08'
 
+    // @PostConstruct
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
     // AOP
     implementation 'org.aspectj:aspectjrt:1.9.20'
     implementation 'org.aspectj:aspectjweaver:1.9.20'
@@ -62,7 +65,6 @@ dependencies {
     implementation('javax.servlet:javax.servlet-api:4.0.1')
     compileOnly 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.3'
     implementation 'javax.servlet:jstl:1.2'
-    compileOnly('jakarta.servlet:jakarta.servlet-api:6.1.0')
 
     // Logging
     implementation 'org.apache.logging.log4j:log4j-api:2.18.0'
@@ -74,7 +76,8 @@ dependencies {
     implementation 'xerces:xercesImpl:2.12.2'
 
     // Jackson
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+//    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
 
     // Database
     implementation 'com.mysql:mysql-connector-j:8.1.0'
@@ -102,12 +105,4 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-}
-
-test {
-    useJUnitPlatform()
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat "full"
-    }
 }

--- a/src/main/java/org/bbagisix/HelloServlet.java
+++ b/src/main/java/org/bbagisix/HelloServlet.java
@@ -2,8 +2,13 @@ package org.bbagisix;
 
 import java.io.*;
 
-import jakarta.servlet.http.*;
-import jakarta.servlet.annotation.*;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+// import jakarta.servlet.http.*;
+// import jakarta.servlet.annotation.*;
 
 @WebServlet(name = "helloServlet", value = "/hello-servlet")
 public class HelloServlet extends HttpServlet {

--- a/src/main/java/org/bbagisix/chat/config/RedisSubscriberInitializer.java
+++ b/src/main/java/org/bbagisix/chat/config/RedisSubscriberInitializer.java
@@ -1,0 +1,38 @@
+package org.bbagisix.chat.config;
+
+import org.bbagisix.chat.service.ChatMessageSubscriber;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriberInitializer {
+
+	private final RedisMessageListenerContainer redisMessageListenerContainer;
+	private final ChatMessageSubscriber chatMessageSubscriber;
+
+	@PostConstruct
+	public void initializeSubscribers() {
+		try {
+			PatternTopic chatChannelPattern = new PatternTopic("chat:channel:*");
+
+			redisMessageListenerContainer.addMessageListener(
+				chatMessageSubscriber,
+				chatChannelPattern
+			);
+
+			log.info("✅ Redis 채팅 채널 구독 초기화 완료: pattern=chat:channel:*");
+
+		} catch (Exception e) {
+			log.error("❌ Redis 구독 초기화 실패: ", e);
+			log.error("Redis 구독 설정 실패 - 채팅 기능이 제한될 수 있습니다.");
+		}
+	}
+}

--- a/src/main/java/org/bbagisix/chat/controller/ChatController.java
+++ b/src/main/java/org/bbagisix/chat/controller/ChatController.java
@@ -13,7 +13,6 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +30,6 @@ public class ChatController {
 
 	private final ChatService chatService;
 	private final ChatSessionService chatSessionService;
-	private final SimpMessagingTemplate messagingTemplate;
 
 	/**
 	 * 참여중인 채팅방 목록 조회
@@ -78,7 +76,7 @@ public class ChatController {
 	}
 
 	/**
-	 * 채팅 메시지 전송 (WebSocket)
+	 * 채팅 메시지 전송
 	 * /app/chat/{challengeId}/send 로 메시지를 받아서
 	 * /topic/chat/{challengeId} 로 브로드캐스트
 	 * DTO → VO → Entity
@@ -97,12 +95,11 @@ public class ChatController {
 			}
 
 			// 메시지를 VO → Entity 변환 후 DB에 저장
+			// Redis pub/sub 발행 (ChatService에서 처리)
 			ChatMessageDTO savedMessage = chatService.saveMessage(chatMessage);
 
 			log.info("메시지 저장 완료: ID {}", savedMessage.getMessageId());
 
-			// 해당 챌린지 구독자들에게 브로드캐스트
-			messagingTemplate.convertAndSend("/topic/chat/" + challengeId, savedMessage);
 		} catch (BusinessException e) {
 			log.warn("비즈니스 예외 발생: code={}, message={}", e.getCode(), e.getMessage());
 			// GlobalExceptionHandler 에서 처리
@@ -113,7 +110,7 @@ public class ChatController {
 	}
 
 	/**
-	 * 사용자가 채팅방에 입장 (WebSocket)
+	 * 사용자가 채팅방에 입장
 	 * 시스템이 제어하는 입장 처리
 	 */
 	@MessageMapping("/chat/{challengeId}/join")
@@ -129,19 +126,19 @@ public class ChatController {
 			log.info("📥 [입장 요청] 사용자 ID: {}, 챌린지 ID: {}", userId, challengeId);
 
 			// ChatService를 통해 사용자 정보와 함께 입장 메시지 생성
+			// Redis 발행
 			ChatMessageDTO systemMessage = chatService.handleJoin(challengeId, userId);
 
 			// userName 안전성 체크
-			if (systemMessage != null && systemMessage.getUserName() != null && !systemMessage.getUserName()
-				.trim()
-				.isEmpty()) {
+			if (systemMessage != null && systemMessage.getUserName() != null &&
+				!systemMessage.getUserName().trim().isEmpty()) {
 				userName = systemMessage.getUserName();
 			}
 
 			// 세션에 정보 저장 - null 값 완전 차단
 			saveToSession(headerAccessor, challengeId, userId, userName);
 
-			// 접속자 수 증가
+			// 접속자 수 증가 (Redis pub/sub로 브로드캐스팅)
 			chatSessionService.addParticipant(challengeId);
 			int currentCount = chatSessionService.getParticipantCount(challengeId);
 
@@ -151,12 +148,6 @@ public class ChatController {
 			if (systemMessage == null) {
 				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "입장 메시지 생성에 실패했습니다.");
 			}
-
-			// 시스템 메시지는 DB에 저장하지 않고 바로 브로드캐스트
-			messagingTemplate.convertAndSend("/topic/chat/" + challengeId, systemMessage);
-
-			// 접속자 수 브로드캐스트
-			messagingTemplate.convertAndSend("/topic/userCount/" + challengeId, currentCount);
 
 			log.info("입장 처리 완료: 사용자 {}, 챌린지 {}", userName, challengeId);
 
@@ -190,20 +181,16 @@ public class ChatController {
 			if (challengeId != null) {
 				log.info("👋 [퇴장 시작] 사용자: {}, 챌린지: {}", userName, challengeId);
 
-				// 접속자 수 감소
+				// 접속자 수 감소 (Redis pub/sub로 브로드캐스트)
 				chatSessionService.removeParticipant(challengeId);
 				int currentCount = chatSessionService.getParticipantCount(challengeId);
 
 				log.info("✅ [퇴장 완료] 사용자: {}, 챌린지: {}, 현재 접속자 수: {}명", userName, challengeId, currentCount);
 
-				// 퇴장 메시지 전송 (VO 기반)
+				// 퇴장 메시지 생성 + Redis 발행
 				if (userName != null) {
 					ChatMessageDTO systemMessage = chatService.handleLeave(challengeId, userId, userName);
-					messagingTemplate.convertAndSend("/topic/chat/" + challengeId, systemMessage);
 				}
-
-				// 접속자 수 브로드캐스트
-				messagingTemplate.convertAndSend("/topic/userCount/" + challengeId, currentCount);
 			}
 		} catch (BusinessException e) {
 			log.warn("퇴장 처리 중 비즈니스 예외: code={}, message={}", e.getCode(), e.getMessage());

--- a/src/main/java/org/bbagisix/chat/converter/ChatMessageConverter.java
+++ b/src/main/java/org/bbagisix/chat/converter/ChatMessageConverter.java
@@ -1,6 +1,6 @@
 package org.bbagisix.chat.converter;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import org.bbagisix.chat.domain.ChatMessageVO;
 import org.bbagisix.chat.dto.ChatMessageDTO;
@@ -23,7 +23,7 @@ public class ChatMessageConverter {
 			.userId(dto.getUserId())
 			.message(dto.getMessage())
 			.messageType(dto.getMessageType() != null ? dto.getMessageType() : "MESSAGE")
-			.sentAt(dto.getSentAt() != null ? dto.getSentAt() : new Timestamp(System.currentTimeMillis()))
+			.sentAt(dto.getSentAt() != null ? dto.getSentAt() : LocalDateTime.now())
 			.userName(dto.getUserName())
 			.build();
 	}
@@ -63,7 +63,7 @@ public class ChatMessageConverter {
 			.userName(entity.getUserName())
 			.build();
 	}
-	
+
 	/**
 	 * VO → DTO 변환 (응답용)
 	 */
@@ -112,7 +112,7 @@ public class ChatMessageConverter {
 			.userName(userName != null ? userName : "사용자" + userId)
 			.message(message)
 			.messageType("SYSTEM")
-			.sentAt(new Timestamp(System.currentTimeMillis()))
+			.sentAt(LocalDateTime.now())
 			.build();
 	}
 
@@ -124,7 +124,7 @@ public class ChatMessageConverter {
 			.challengeId(challengeId)
 			.message(message)
 			.messageType("ERROR")
-			.sentAt(new Timestamp(System.currentTimeMillis()))
+			.sentAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/src/main/java/org/bbagisix/chat/domain/ChatMessageVO.java
+++ b/src/main/java/org/bbagisix/chat/domain/ChatMessageVO.java
@@ -1,6 +1,6 @@
 package org.bbagisix.chat.domain;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +12,7 @@ public class ChatMessageVO {
 	private final Long userId;
 	private final String message;
 	private final String messageType;
-	private final Timestamp sentAt;
+	private final LocalDateTime sentAt;
 	private final String userName;
 
 	// 비즈니스 로직 메서드

--- a/src/main/java/org/bbagisix/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/org/bbagisix/chat/dto/ChatMessageDTO.java
@@ -1,6 +1,6 @@
 package org.bbagisix.chat.dto;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -30,7 +30,7 @@ public class ChatMessageDTO {
 	@Size(min = 1, max = 255, message = "메시지는 1자 이상 255자 이하여야 합니다")
 	private String message;      // message (VARCHAR)
 
-	private Timestamp sentAt;    // sent_at (DATETIME)
+	private LocalDateTime sentAt;    // sent_at (DATETIME)
 	private String messageType;  // message_type (VARCHAR)
 
 	// 추가 필드 (Join)
@@ -42,6 +42,6 @@ public class ChatMessageDTO {
 		this.userId = userId;
 		this.message = message;
 		this.messageType = messageType;
-		this.sentAt = new Timestamp(System.currentTimeMillis());
+		this.sentAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/org/bbagisix/chat/entity/ChatMessage.java
+++ b/src/main/java/org/bbagisix/chat/entity/ChatMessage.java
@@ -1,6 +1,6 @@
 package org.bbagisix.chat.entity;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +16,7 @@ public class ChatMessage {
 	private Long challengeId;
 	private Long userId;
 	private String message;
-	private Timestamp sentAt;
+	private LocalDateTime sentAt;
 	private String messageType;
 
 	// DB 조인 결과용 (사용자 정보)

--- a/src/main/java/org/bbagisix/chat/service/ChatMessagePublisher.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatMessagePublisher.java
@@ -3,6 +3,7 @@ package org.bbagisix.chat.service;
 import org.bbagisix.chat.dto.ChatMessageDTO;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ChatMessagePublisher {
 
+	@Qualifier("chatRedisTemplate")
 	private final RedisTemplate<String, Object> redisTemplate;    // pub/sub 메시지 발행 및 데이터 저장/조회
 
 	private static final String CHAT_CHANNEL_PREFIX = "chat:channel:";    // 채팅방 별 격리와 패턴 매칭 위해 사용

--- a/src/main/java/org/bbagisix/chat/service/ChatMessagePublisher.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatMessagePublisher.java
@@ -1,0 +1,51 @@
+package org.bbagisix.chat.service;
+
+import org.bbagisix.chat.dto.ChatMessageDTO;
+import org.bbagisix.exception.BusinessException;
+import org.bbagisix.exception.ErrorCode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessagePublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;    // pub/sub 메시지 발행 및 데이터 저장/조회
+
+	private static final String CHAT_CHANNEL_PREFIX = "chat:channel:";    // 채팅방 별 격리와 패턴 매칭 위해 사용
+
+	/**
+	 * 특정 챌린지 채널로 메시지 발행
+	 */
+	public void publishMessage(Long challengeId, ChatMessageDTO message) {
+		try {
+			String channel = CHAT_CHANNEL_PREFIX + challengeId;
+
+			log.debug("Redis로 메시지 발행: channel={}, message={}", channel, message.getMessage());
+
+			// Redis pub/sub로 메시지 발행
+			redisTemplate.convertAndSend(channel, message);
+
+			log.debug("메시지 발행 완료: challengeId={}", challengeId);
+		} catch (Exception e) {
+			log.error("Redis 메시지 발행 중 오류: challengeId={}", challengeId, e);
+			throw new BusinessException(ErrorCode.WEBSOCKET_SEND_FAILED, e);
+		}
+	}
+
+	/**
+	 * 접속자 수 변경 브로드캐스트
+	 */
+	public void publishParticipantCount(Long challengeId, int count) {
+		ChatMessageDTO countMessage = ChatMessageDTO.builder()
+			.challengeId(challengeId)
+			.messageType("PARTICIPANT_COUNT")
+			.userId(0L)        // 시스템 메시지
+			.message(String.valueOf(count))
+			.build();
+	}
+}

--- a/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
@@ -1,5 +1,7 @@
 package org.bbagisix.chat.service;
 
+import java.util.Map;
+
 import org.bbagisix.chat.dto.ChatMessageDTO;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -61,9 +63,18 @@ public class ChatMessageSubscriber implements MessageListener {
 		try {
 			if ("PARTICIPANT_COUNT".equals(chatMessage.getMessageType())) {
 				int count = Integer.parseInt(chatMessage.getMessage());
-				// 접속자 수 업데이트 메시지
-				messagingTemplate.convertAndSend("/topic/userCount/" + challengeId, count);
+
+				// 접속자 수 업데이트 메시지 - Map
+				Map<String, Object> countMessage = Map.of(
+					"type", "PARTICIPANT_COUNT",
+					"challengeId", challengeId,
+					"count", count
+				);
+
+				// 채팅 채널로 통합 전송 (프론트엔드에서 하나의 구독으로 처리)
+				messagingTemplate.convertAndSend("/topic/chat/" + challengeId, countMessage);
 				log.debug("접속자 수 업데이트 전송: challengeId={}, count={}", challengeId, count);
+
 			} else {
 				// 일반 채팅 메시지
 				messagingTemplate.convertAndSend("/topic/chat/" + challengeId, chatMessage);

--- a/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
@@ -1,0 +1,90 @@
+package org.bbagisix.chat.service;
+
+import org.bbagisix.chat.dto.ChatMessageDTO;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageSubscriber implements MessageListener {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final ObjectMapper objectMapper = new ObjectMapper()
+		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+		.findAndRegisterModules();
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			// 채널명 추출
+			String channel = new String(message.getChannel());
+			String messageBody = new String(message.getBody());
+
+			log.debug("Redis에서 메시지 수신: channel={}, body={}", channel, messageBody);
+
+			// JSON -> ChatMessageDTO (역직렬화)
+			ChatMessageDTO chatMessage = objectMapper.readValue(messageBody, ChatMessageDTO.class);
+
+			// 채널명에서 challengeId 추출
+			Long challengeId = extractChallengeIdFromChannel(channel);
+
+			if (challengeId == null) {
+				log.warn("잘못된 채널 형식: {}", channel);
+				return;
+			}
+
+			// 메시지 타입에 따른 처리
+			handleMessage(challengeId, chatMessage);
+
+		} catch (Exception e) {
+			log.error("Redis 메시지 처리 중 오류 (무시하고 계속): ", e);
+		}
+	}
+
+	/**
+	 * 메시지 타입에 따른 처리
+	 * @param challengeId
+	 * @param chatMessage
+	 */
+	private void handleMessage(Long challengeId, ChatMessageDTO chatMessage) {
+		try {
+			if ("PARTICIPANT_COUNT".equals(chatMessage.getMessageType())) {
+				int count = Integer.parseInt(chatMessage.getMessage());
+				// 접속자 수 업데이트 메시지
+				messagingTemplate.convertAndSend("/topic/userCount/" + challengeId, count);
+				log.debug("접속자 수 업데이트 전송: challengeId={}, count={}", challengeId, count);
+			} else {
+				// 일반 채팅 메시지
+				messagingTemplate.convertAndSend("/topic/chat/" + challengeId, chatMessage);
+				log.debug("채팅 메시지 전송: challengeId={}, messageType={}", challengeId, chatMessage.getMessageType());
+			}
+		} catch (Exception e) {
+			log.error("WebSocket 메시지 전송 중 오류 (무시하고 계속): challengeId={}", challengeId, e);
+		}
+	}
+
+	/**
+	 * 채널명에서 challengeId 추출
+	 * "chat:channel:123" -> 123
+	 */
+	private Long extractChallengeIdFromChannel(String channel) {
+		try {
+			if (channel != null && channel.startsWith("chat:channel:")) {
+				String idPart = channel.substring("chat:channel:".length());
+				return Long.parseLong(idPart);
+			}
+		} catch (NumberFormatException e) {
+			log.warn("challengeId 파싱 실패: channel={}", channel);
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatMessageSubscriber.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,8 @@ public class ChatMessageSubscriber implements MessageListener {
 
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ObjectMapper objectMapper = new ObjectMapper()
-		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)    // 알 수 없는 필드 무시
+		.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)    // ISO 문자열로 직렬화
 		.findAndRegisterModules();
 
 	@Override

--- a/src/main/java/org/bbagisix/chat/service/ChatSessionService.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatSessionService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatSessionService {
 
 	private final SimpMessagingTemplate messagingTemplate;
+	private final ChatMessagePublisher chatMessagePublisher;
 
 	// challengeId 별 현재 접속자 수 저장 (메모리 기반)
 	private final Map<Long, Integer> challengeParticipantCount = new ConcurrentHashMap<>();
@@ -28,8 +29,15 @@ public class ChatSessionService {
 
 		log.info("챌린지 {} 접속사 증가: {} 명", challengeId, currentCount);
 
-		// 접속자 수 변경을 모든 클라이언트에게 브로드캐스트
-		broadcastParticipantCount(challengeId, currentCount);
+		// Redis pub/sub로 접속자 수 브로드캐스트
+		try {
+			chatMessagePublisher.publishParticipantCount(challengeId, currentCount);
+			log.debug("접속자 수 Redis 발행 완료: challengeId={}, count={}", challengeId, currentCount);
+		} catch (Exception e) {
+			log.error("접속자 수 Redis 발행 실패 (무시하고 계속): challengeId={}, count={}",
+				challengeId, currentCount, e);
+			// Redis 발행 실패해도 서비스는 계속 동작
+		}
 	}
 
 	/**
@@ -40,8 +48,15 @@ public class ChatSessionService {
 			int newCount = Math.max(0, count - 1);
 			log.info("챌린지 {} 접속자 감소: {} 명", challengeId, newCount);
 
-			// 접속자 수 변경을 모든 클라이언트에게 브로드캐스트
-			broadcastParticipantCount(challengeId, newCount);
+			// Redis pub/sub로 접속자 수 브로드캐스트
+			try {
+				chatMessagePublisher.publishParticipantCount(challengeId, newCount);
+				log.debug("접속자 수 Redis 발행 완료: challengeId={}, count={}", challengeId, newCount);
+			} catch (Exception e) {
+				log.error("접속자 수 Redis 발행 실패 (무시하고 계속): challengeId={}, count={}",
+					challengeId, newCount, e);
+				// Redis 발행 실패해도 서비스는 계속 동작
+			}
 
 			return newCount == 0 ? null : newCount;        // 0이면 맵에서 제거
 		});
@@ -56,7 +71,9 @@ public class ChatSessionService {
 
 	/**
 	 * 접속자 수를 모든 구독자에게 브로드캐스트
+	 * Redis pub/sub가 대신 처리하므로 더 이상 필요 없음
 	 */
+	/*
 	public void broadcastParticipantCount(Long challengeId, int count) {
 		Map<String, Object> countMessage = Map.of(
 			"type", "PARTICIPANT_COUNT",
@@ -66,4 +83,5 @@ public class ChatSessionService {
 
 		messagingTemplate.convertAndSend("/topic/chat/" + challengeId, countMessage);
 	}
+	*/
 }

--- a/src/main/java/org/bbagisix/config/RedisConfig.java
+++ b/src/main/java/org/bbagisix/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package org.bbagisix.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisConnectionFactory redisConnectionFactory;
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+		template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+		return template;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer() {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		return container;
+	}
+}

--- a/src/main/java/org/bbagisix/config/RootConfig.java
+++ b/src/main/java/org/bbagisix/config/RootConfig.java
@@ -17,7 +17,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
@@ -109,6 +111,14 @@ public class RootConfig {
 		properties.put("mail.smtp.starttls.enable", "true");
 
 		return properties;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory());
+		template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+		return template;
 	}
 
 	@Bean


### PR DESCRIPTION
## 📌 관련 이슈
closed #83 

## ✨ 내용
1. Redis pub/sub 아키텍쳐 도입: `ChatMessagePublisher`(발행자)와 `ChatMessageSubscriber`(구독자)를 통해 다중 서버 간 실시간 메시지 동기화 구현
2. 메시지 직렬화 개선
- `TimeStamp`에서 `LocalDateTime`으로 변경
- Jackson ObjectMapper 설정 통일하여 JSON 직렬화/역직렬화
3. 컨트롤러 역할 분리
- WebSocket은 메시지 수신만 담당
- 메시지 전송은 Redis pub/sub -> Subscriber -> WebSocket 경로로 일원화

### 수정된 아키텍쳐
```
[Client A] ←→ [Server 1] ←→ [Service] ←→ [DB]
                   ↓                      ↓
           [WebSocket]   [Redis Pub]
                   ↑                      ↓
[Client B] ←→ [Server 2] ←→ [Redis Sub]
```
- pub: 메시지 저장 후 `chat:channel:{challengeId}` 채널로 Redis 발행
- sub: 모든 서버가 `chat:channel:*` 패턴을 구독하여 해당 채팅방 사용자들에게 WebSocket 전송
- Client: 웹소켓을 통해 각각 다른 서버에 연결된 클라이언트들, 실시간 메시지 송수신을 위해 지속적인 연결 유지
- Server: 클라이언트와의 WebSocket 연결 관리, Redis와의 pub/sub 통신 담당

**데이터 흐름 시나리오**
1. Client A가 Server 1에 메시지 전송
2. Server 1이 Service를 통해 DB에 메시지 저장
3. Server 1이 Redis Pub에 메시지 발행
4. Redis Sub가 메시지를 구독하여 Server 2에 전달
5. Server 2가 연결된 Client B에게 웹소켓으로 메시지 전송

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
