### PR TITLE
[FIX] SecurityConfig에 CORS 설정 추가

### DIFF
--- a/src/main/java/org/bbagisix/config/ServletConfig.java
+++ b/src/main/java/org/bbagisix/config/ServletConfig.java
@@ -50,16 +50,5 @@ public class ServletConfig implements WebMvcConfigurer {
 		return resolver;
 	}
 
-	@Override
-	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/api/**").allowedOrigins("http://localhost:5173", // 로컬에서 테스트 할 Vue 개발 서버 주소
-			"https://dondothat.netlify.app" // 실제 배포된 프론트엔드 주소
-		).allowedMethods("GET", "POST", "PUT", "DELETE").allowCredentials(true).allowedHeaders("*");
-
-		registry.addMapping("/ws/**") // '/ws/'로 시작하는 모든 경로를 허용
-			.allowedOrigins("http://localhost:5173", "https://dondothat.netlify.app")
-			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-			.allowCredentials(true)
-			.allowedHeaders("*");
-	}
+	
 }

--- a/src/main/java/org/bbagisix/oauth2/config/SecurityConfig.java
+++ b/src/main/java/org/bbagisix/oauth2/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package org.bbagisix.oauth2.config;
 
 import org.bbagisix.oauth2.service.CustomOAuth2UserService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -10,13 +9,18 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -33,6 +37,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
+
+		// CORS 설정
+		http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
 		
 		// csrf disable
 		http.csrf().disable();
@@ -50,7 +57,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		// 경로별 인가 작업 (OAuth2 경로 허용)
 		http.authorizeRequests()
 			.antMatchers("/", "/oauth2-login", "/oauth2-success", "/error", "/resources/**", 
-						"/oauth2/**", "/login/oauth2/**", "/debug/**").permitAll()
+						"/oauth2/**", "/login/oauth2/**", "/debug/**", "/api/**", "/ws/**").permitAll()
 			.anyRequest().authenticated();
 
 		// OAuth2 로그인 설정 - 이것이 필터를 자동 등록해야 함
@@ -62,6 +69,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.defaultSuccessUrl("/oauth2-success", true)
 			.failureUrl("/oauth2-login?error");
 	}
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "https://dondothat.netlify.app"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위 설정 적용
+        return source;
+    }
 
 	@Bean
 	public static ClientRegistrationRepository clientRegistrationRepository(Environment environment) {


### PR DESCRIPTION
## 📌 관련 이슈
closed #96 

## ✨ 내용
ServletConfig에 CORS 설정을 추가했지만, WebMvcConfigurer의 CORS 설정이 충돌하여 WebMvcConfigurer에서 설정한 CORS 정책이 Spring Security 필터보다 먼저 적용되지 않아 SecurityConfig에 CORS 설정을 추가
ServletConfig의 CORS 설정은 제거
