### PR TITLE
[FEAT] 이전 채팅 불러오기

### DIFF
--- a/src/main/java/org/bbagisix/chat/dto/ChatHistoryDTO.java
+++ b/src/main/java/org/bbagisix/chat/dto/ChatHistoryDTO.java
@@ -1,0 +1,28 @@
+package org.bbagisix.chat.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatHistoryDTO {
+
+	private Long messageId;
+	private Long challengeId;
+	private Long userId;
+	private String message;
+	private LocalDateTime sentAt;
+	private String messageType;
+	private String userName;
+
+	// 추가 정보 (필요시)
+	// private final Boolean isMyMessage;
+}

--- a/src/main/java/org/bbagisix/chat/dto/UserChallengeInfoDTO.java
+++ b/src/main/java/org/bbagisix/chat/dto/UserChallengeInfoDTO.java
@@ -1,0 +1,41 @@
+package org.bbagisix.chat.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor
+public class UserChallengeInfoDTO {
+
+	private Long userChallengeId;
+	private Long userId;
+	private Long challengeId;
+	private String challengeName;
+	private String status;        // ongoing, completed, failed
+	private LocalDateTime startDate;    // 메시지 이력 조회 시작점
+	private LocalDateTime endDate;        // 챌린지 종료일 (참고용)
+
+	/**
+	 * 채팅방 접근 가능한지 확인
+	 * ongoing 상태일 때만 채팅방 접근 가능
+	 */
+	public boolean canAccessChatRoom() {
+		return "ongoing".equals(status);
+	}
+
+	/**
+	 * 챌린지가 종료되었는지 확인
+	 * completed 또는 failed 상태일 때 종료
+	 */
+	public boolean isFinished() {
+		return "completed".equals(status) || "failed".equals(status);
+	}
+}

--- a/src/main/java/org/bbagisix/chat/dto/response/UserChallengeStatusResponse.java
+++ b/src/main/java/org/bbagisix/chat/dto/response/UserChallengeStatusResponse.java
@@ -1,0 +1,20 @@
+package org.bbagisix.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserChallengeStatusResponse {
+
+	private final Long userId;
+	private final Long challengeId;
+	private final String challengeName;
+	private final Boolean hasActiveChallenge;
+	private final String status;
+	private final String message;
+	private final LocalDateTime startDate;
+	private final LocalDateTime endDate;
+}

--- a/src/main/java/org/bbagisix/chat/mapper/ChatMapper.java
+++ b/src/main/java/org/bbagisix/chat/mapper/ChatMapper.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.bbagisix.chat.dto.ChatHistoryDTO;
+import org.bbagisix.chat.dto.UserChallengeInfoDTO;
 import org.bbagisix.chat.entity.ChatMessage;
 
 @Mapper
@@ -24,4 +26,20 @@ public interface ChatMapper {
 
 	// 특정 챌린지의 참여자 목록 조회
 	List<Map<String, Object>> selectParticipants(@Param("challengeId") Long challengeId);
+
+	// 사용자가 챌린지에 참여한 시점 이후의 채팅 메시지 조회
+	List<ChatHistoryDTO> selectChatHistoryByUserParticipation(
+		@Param("challengeId") Long challengeId,
+		@Param("userId") Long userId,
+		@Param("limit") int limit
+	);
+
+	// 사용자가 해당 챌린지에 현재 참여 중인지 확인
+	UserChallengeInfoDTO selectUserChallengeStatus(
+		@Param("challengeId") Long challengeId,
+		@Param("userId") Long userId
+	);
+
+	// 사용자의 현재 활성 챌린지 정보 조회
+	UserChallengeInfoDTO selectUserActiveChallengeInfo(@Param("userId") Long userId);
 }

--- a/src/main/java/org/bbagisix/config/RedisConfig.java
+++ b/src/main/java/org/bbagisix/config/RedisConfig.java
@@ -1,10 +1,12 @@
 package org.bbagisix.config;
 
+import org.bbagisix.chat.service.ChatMessageSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -45,6 +47,19 @@ public class RedisConfig {
 		template.setHashKeySerializer(serializer);
 
 		return template;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+		ChatMessageSubscriber chatMessageSubscriber) {  // 의존성 주입 추가
+
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+
+		container.addMessageListener(chatMessageSubscriber,
+			new PatternTopic("chat:channel:*"));
+
+		return container;
 	}
 
 	@Bean

--- a/src/main/resources/mappers/chat/ChatMapper.xml
+++ b/src/main/resources/mappers/chat/ChatMapper.xml
@@ -16,6 +16,17 @@
         <result property="userName" column="user_name"/>
     </resultMap>
 
+    <!-- ChatHistoryDto ResultMap -->
+    <resultMap id="ChatHistoryResultMap" type="org.bbagisix.chat.dto.ChatHistoryDTO">
+        <result column="messageId" property="messageId"/>
+        <result column="challengeId" property="challengeId"/>
+        <result column="userId" property="userId"/>
+        <result column="message" property="message"/>
+        <result column="sentAt" property="sentAt" javaType="java.time.LocalDateTime"/>
+        <result column="messageType" property="messageType"/>
+        <result column="userName" property="userName"/>
+    </resultMap>
+
     <!-- 채팅 메시지 저장 -->
     <insert id="insertMessage" parameterType="org.bbagisix.chat.entity.ChatMessage"
             useGeneratedKeys="true" keyProperty="messageId">
@@ -82,4 +93,58 @@
           AND uc.status = 'ongoing'
         ORDER BY uc.start_date ASC
     </select>
+
+    <!-- 사용자가 참여한 시점 이후의 채팅 메시지 조회 -->
+    <select id="selectChatHistoryByUserParticipation" resultMap="ChatHistoryResultMap">
+        SELECT cm.message_id                               as messageId,
+               cm.challenge_id                             as challengeId,
+               cm.user_id                                  as userId,
+               cm.message,
+               cm.sent_at                                  as sentAt,
+               cm.message_type                             as messageType,
+               COALESCE(u.name, CONCAT('사용자', cm.user_id)) as userName
+        FROM chat_message cm
+                 LEFT JOIN user u ON cm.user_id = u.user_id
+        WHERE cm.challenge_id = #{challengeId}
+          AND cm.sent_at >= (SELECT uc.start_date
+                             FROM user_challenge uc
+                             WHERE uc.user_id = #{userId}
+                               AND uc.challenge_id = #{challengeId}
+                               AND uc.status = 'ongoing')
+        ORDER BY cm.sent_at ASC
+            LIMIT #{limit}
+    </select>
+
+    <!-- 사용자의 특정 챌린지 참여 상태 확인 -->
+    <select id="selectUserChallengeStatus" resultType="org.bbagisix.chat.dto.UserChallengeInfoDTO">
+        SELECT uc.user_challenge_id as userChallengeId,
+               uc.user_id           as userId,
+               uc.challenge_id      as challengeId,
+               c.title              as challengeName,
+               uc.status,
+               uc.start_date        as startDate,
+               uc.end_date          as endDate
+        FROM user_challenge uc
+                 JOIN challenge c ON uc.challenge_id = c.challenge_id
+        WHERE uc.user_id = #{userId}
+          AND uc.challenge_id = #{challengeId}
+          AND uc.status = 'ongoing'
+    </select>
+
+    <!-- 사용자의 현재 활성 챌린지 정보 조회 -->
+    <select id="selectUserActiveChallengeInfo" resultType="org.bbagisix.chat.dto.UserChallengeInfoDTO">
+        SELECT uc.user_challenge_id as userChallengeId,
+               uc.user_id           as userId,
+               uc.challenge_id      as challengeId,
+               c.title              as challengeName,
+               uc.status,
+               uc.start_date        as startDate,
+               uc.end_date          as endDate
+        FROM user_challenge uc
+                 JOIN challenge c ON uc.challenge_id = c.challenge_id
+        WHERE uc.user_id = #{userId}
+          AND uc.status = 'ongoing'
+        ORDER BY uc.start_date DESC LIMIT 1
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
closed #103 

## ✨ 내용
1. 주요 기능
- 챌린지 상태 확인 - 사용자의 활성 챌린지 여부 조회
- 채팅 이력 조회 - 사용자가 참여한 시점 이후의 모든 메시지 로드
- 권한 검증 - 챌린지 참여자만 채팅 이력 접근 가능
- 타입 안전성 - DTO 기반으로 유지보수성 향상

2. 핵심 로직
- 사용자가 status='ongoing'인 챌린지에 참여 중일 때만 채팅방 접근 허용
- start_date 이후의 채팅 메시지만 조회하여 참여 전 내용은 보이지 않음
- DTO 기반 타입 안전한 데이터 처리

3. 추후 개선사항
- 메시지 전송 시간 오류 해결
- 메시지 발신자 구분 필요
- 입/퇴장 메시지 순서 보장

## 📸 스크린샷(선택)
<img width="389" height="717" alt="Screenshot 2025-08-04 at 3 09 55 PM" src="https://github.com/user-attachments/assets/0715de40-8304-4176-a72c-0d6506d04051" />


## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
