### PR TITLE
[FEAT] 회원가입시, 사용자 나이 입력 & DB  저장

### DIFF
--- a/src/main/java/org/bbagisix/user/domain/UserVO.java
+++ b/src/main/java/org/bbagisix/user/domain/UserVO.java
@@ -17,6 +17,7 @@ public class UserVO {
 	private String email;
 	private String password;
 	private String nickname;
+	private Integer age;
 	private String socialId;
 	private String role;
 	private boolean emailVerified;

--- a/src/main/java/org/bbagisix/user/dto/CustomOAuth2User.java
+++ b/src/main/java/org/bbagisix/user/dto/CustomOAuth2User.java
@@ -52,4 +52,8 @@ public class CustomOAuth2User implements OAuth2User {
 	public Long getUserId() {
 		return userResponse.getUserId();
 	}
+
+	public Integer getAge() {
+		return userResponse.getAge();
+	}
 }

--- a/src/main/java/org/bbagisix/user/dto/SignUpRequest.java
+++ b/src/main/java/org/bbagisix/user/dto/SignUpRequest.java
@@ -3,6 +3,7 @@ package org.bbagisix.user.dto;
 import javax.validation.constraints.Email;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,4 +27,7 @@ public class SignUpRequest {
 	@NotBlank(message = "이메일은 필수입니다.")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	private String email;
+
+	@NotNull(message = "나이는 필수입니다.")
+	private Integer age;
 }

--- a/src/main/java/org/bbagisix/user/dto/UserResponse.java
+++ b/src/main/java/org/bbagisix/user/dto/UserResponse.java
@@ -12,6 +12,7 @@ public class UserResponse {
     private String name;
     private String email;
     private String nickname;
+    private Integer age;
     private String role;
 	private boolean assetConnected;
 }

--- a/src/main/java/org/bbagisix/user/service/UserService.java
+++ b/src/main/java/org/bbagisix/user/service/UserService.java
@@ -47,6 +47,7 @@ public class UserService {
 			.name(userVO.getName())
 			.email(userVO.getEmail())
 			.nickname(userVO.getNickname())
+			.age(userVO.getAge())
 			.role(userVO.getRole())
 			.assetConnected(userVO.isAssetConnected())
 			.build();
@@ -77,6 +78,7 @@ public class UserService {
 			.nickname(signUpRequest.getNickname())
 			.password(encodedPassword)
 			.email(signUpRequest.getEmail())
+			.age(signUpRequest.getAge())
 			.emailVerified(false)
 			.assetConnected(false)
 			.role("USER")

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -6,8 +6,8 @@
 <mapper namespace="org.bbagisix.user.mapper.UserMapper">
 
     <insert id="insertUser" parameterType="org.bbagisix.user.domain.UserVO" useGeneratedKeys="true" keyProperty="userId">
-        insert into user (name, nickname, password, email, email_verified, role, social_id)
-        values (#{name}, #{nickname}, #{password}, #{email}, #{emailVerified}, #{role}, #{socialId})
+        insert into user (name, nickname, password, email, age, email_verified, role, social_id)
+        values (#{name}, #{nickname}, #{password}, #{email}, #{age}, #{emailVerified}, #{role}, #{socialId})
     </insert>
 
     <select id="selectUserByEmail" resultType="org.bbagisix.user.domain.UserVO">


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#120 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- UserVO, UserResponse(DTO)에 나이 필드(age) 추가
- 회원가입시, 입력 받은 나이 저장
- 사용자 정보 호출 반환 시, 나이 필드 포함

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

사용자 정보 호출 `/me` 예시
<img width="335" height="182" alt="image" src="https://github.com/user-attachments/assets/348937a9-49eb-491e-b6ba-26e54009bdd9" />


## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
관련 프론트엔드 작업
https://github.com/bbaegi-six/dondothat-client/pull/71