### PR TITLE
[FIX] 채팅 JWT 로직 적용

### DIFF
--- a/src/main/java/org/bbagisix/chat/interceptior/WebSocketJwtInterceptor.java
+++ b/src/main/java/org/bbagisix/chat/interceptior/WebSocketJwtInterceptor.java
@@ -1,0 +1,145 @@
+package org.bbagisix.chat.interceptior;
+
+import java.util.List;
+import java.util.Map;
+
+import org.bbagisix.user.dto.CustomOAuth2User;
+import org.bbagisix.user.dto.UserResponse;
+import org.bbagisix.user.util.JwtUtil;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket STOMP 연결 시 JWT 토큰 검증 인터셉터 (쿠키만 지원)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketJwtInterceptor implements ChannelInterceptor {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+			// STOMP 연결 시 JWT 토큰 검증
+			authenticateUser(accessor);
+		}
+
+		return message;
+	}
+
+	/**
+	 * WebSocket 연결 시 JWT 토큰으로 사용자 인증
+	 */
+	private void authenticateUser(StompHeaderAccessor accessor) {
+		try {
+			String token = extractTokenFromCookie(accessor);
+
+			if (token == null) {
+				log.warn("❌ WebSocket 연결: JWT 토큰이 없습니다");
+				return;
+			}
+
+			// JWT 토큰 검증
+			if (!jwtUtil.isExpired(token)) {
+				log.warn("❌ WebSocket 연결: 유효하지 않은 JWT 토큰");
+				return;
+			}
+
+			// 토큰에서 사용자 정보 추출
+			String email = jwtUtil.getEmail(token);
+			String name = jwtUtil.getName(token);    // email 반환
+			String nickname = jwtUtil.getNickname(token);
+			Long userId = jwtUtil.getUserId(token);
+
+			// 실제 이름은 nickname을 사용
+			String displayName = nickname != null ? nickname : name;
+			log.info("✅ WebSocket JWT 인증 성공: userId={}, email={}, nickname={}", userId, email, nickname);
+
+			// UserResponse 객체 생성
+			UserResponse userResponse = UserResponse.builder()
+				.userId(userId)
+				.email(email)
+				.name(displayName)
+				.nickname(nickname)
+				.role("USER")
+				.build();
+
+			// CustomOAuth2User 객체 생성
+			CustomOAuth2User customUser = new CustomOAuth2User(userResponse);
+
+			// Authentication 객체 생성
+			Authentication auth = new UsernamePasswordAuthenticationToken(
+				customUser,
+				null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER"))
+			);
+
+			// WebSocket 세션에 인증 정보 저장
+			accessor.setUser(auth);
+
+			// 세션 속성에 사용자 정보 저장 (채팅에서 사용)
+			Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+			if (sessionAttributes != null) {
+				sessionAttributes.put("userId", userId);
+				sessionAttributes.put("userName", displayName);    // nickname 사용
+				sessionAttributes.put("email", email);
+				sessionAttributes.put("authenticated", true);
+			}
+
+			log.info("📝 WebSocket 세션에 사용자 정보 저장 완료: userId={}", userId);
+		} catch (Exception e) {
+			log.error("❌ WebSocket JWT 인증 중 오류 발생: {}", e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Cookie에서 JWT 토큰 추출
+	 */
+	private String extractTokenFromCookie(StompHeaderAccessor accessor) {
+		List<String> cookieHeaders = accessor.getNativeHeader("Cookie");
+		if (cookieHeaders != null && !cookieHeaders.isEmpty()) {
+			for (String cookieHeader : cookieHeaders) {
+				String token = parseJwtFromCookie(cookieHeader);
+				if (token != null) {
+					log.debug("🍪 Cookie에서 JWT 토큰 추출 성공");
+					return token;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Cookie 문자열에서 JWT 토큰 파싱
+	 */
+	private String parseJwtFromCookie(String cookieHeader) {
+		if (cookieHeader == null)
+			return null;
+
+		String[] cookies = cookieHeader.split(";");
+		for (String cookie : cookies) {
+			String[] parts = cookie.trim().split("=", 2);    // key=value
+			if (parts.length == 2 && "jwt".equals(parts[0].trim())) {
+				return parts[1].trim();        // JWT 토큰 반환
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/org/bbagisix/config/WebSocketConfig.java
+++ b/src/main/java/org/bbagisix/config/WebSocketConfig.java
@@ -1,21 +1,35 @@
 package org.bbagisix.config;
 
+import org.bbagisix.chat.interceptior.WebSocketJwtInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket 설정 - JWT 인증 및 CORS 강화
+ */
+@Slf4j
 @Configuration
-// @EnableWebSocket
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final WebSocketJwtInterceptor webSocketJwtInterceptor;
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry config) {
 		// 메시지 브로커 설정
-		config.enableSimpleBroker("/topic");
-		config.setApplicationDestinationPrefixes("/app");
+		config.enableSimpleBroker("/topic", "/queue");    // 구독 경로
+		config.setApplicationDestinationPrefixes("/app");        // 메시지 전송 경로
+		config.setUserDestinationPrefix("/user");        // 개인 메시지 경로
+
+		log.info("[WebSocketConfig] 메시지 브로커 설정 완료");
 	}
 
 	@Override
@@ -24,5 +38,41 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry.addEndpoint("/ws/chat")
 			.setAllowedOriginPatterns("*")        // CORS 설정 (구체적인 도메인으로 추후 변경)
 			.withSockJS();                // SockJS fallback 옵션
+
+		registry.addEndpoint("/ws/chat")
+			.setAllowedOriginPatterns(
+				"http://localhost:*",
+				"http://127.0.0.1:*",
+				"https://*.netlify.app",
+				"http://dondothat.duckdns.org:*"
+			)
+			.withSockJS()
+			.setHeartbeatTime(25000)    // 하트비트 주기 (클라이언트와 연결 상태 유지)
+			.setDisconnectDelay(5000)   // 연결 종료까지 지연 시간
+			.setSessionCookieNeeded(false); // SockJS 세션 쿠키 비활성화 (JWT 사용)
+
+		log.info("[WebSocketConfig] STOMP 엔드포인트 등록 완료: /ws/chat");
+
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		// 클라이언트 → 서버 메시지 채널: 인터셉터 추가로 인증 처리
+		registration.interceptors(webSocketJwtInterceptor);
+		registration.taskExecutor().corePoolSize(4);
+		registration.taskExecutor().maxPoolSize(8);
+		registration.taskExecutor().keepAliveSeconds(60);
+
+		log.info("[WebSocketConfig] WebSocket JWT 인터셉터 등록 완료");
+	}
+
+	@Override
+	public void configureClientOutboundChannel(ChannelRegistration registration) {
+		// 서버에서 클라이언트로 가는 메시지 처리
+		registration.taskExecutor().corePoolSize(4);
+		registration.taskExecutor().maxPoolSize(8);
+		registration.taskExecutor().keepAliveSeconds(60);
+
+		log.info("[WebSocketConfig] 아웃바운드 채널 설정 완료");
 	}
 }

--- a/src/main/java/org/bbagisix/config/WebSocketConfig.java
+++ b/src/main/java/org/bbagisix/config/WebSocketConfig.java
@@ -35,11 +35,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		// STOMP 엔드포인트 등록
-		registry.addEndpoint("/ws/chat")
+		registry.addEndpoint("/api/ws/chat")
 			.setAllowedOriginPatterns("*")        // CORS 설정 (구체적인 도메인으로 추후 변경)
 			.withSockJS();                // SockJS fallback 옵션
 
-		registry.addEndpoint("/ws/chat")
+		registry.addEndpoint("/api/ws/chat")
 			.setAllowedOriginPatterns(
 				"http://localhost:*",
 				"http://127.0.0.1:*",


### PR DESCRIPTION
## 📌 관련 이슈
closed #115 

## ✨ 내용
1. WebSocket JWT 인터셉터 구현
- `WebSocketJwtInterceptor.java`
- WebSocket 연결 시 JWT 쿠키를 자동으로 검증하고 사용자 인증 처리

2. WebSocket 설정 강화
- `WebSocketConfig.java`
- JWT 인터셉터를 WebSocket 채널에 등록

3. `ChatController` API 확장
- 신규 엔드포인트:
```
@GetMapping("/api/chat/status/me")        // JWT 기반 사용자 상태 조회
@GetMapping("/api/chat/user/me")          // JWT 기반 채팅방 조회  
@GetMapping("/api/chat/{challengeId}/messages") // JWT 기반 메시지 이력
```
- 기존 엔드포인트 유지

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
