### PR TITLE
[REFACTOR] 과소비 카테고리 분석 로직 수정

### DIFF
--- a/src/main/java/org/bbagisix/analytics/service/AnalyticsService.java
+++ b/src/main/java/org/bbagisix/analytics/service/AnalyticsService.java
@@ -2,8 +2,6 @@ package org.bbagisix.analytics.service;
 
 import java.util.List;
 
-import org.bbagisix.category.dto.CategoryDTO;
-
 public interface AnalyticsService {
-	List<CategoryDTO> getTopCategories(Long userId);
+	List<Long> getTopCategories(Long userId);
 }

--- a/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
+++ b/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
@@ -1,11 +1,9 @@
 package org.bbagisix.analytics.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.bbagisix.category.dto.CategoryDTO;
 import org.bbagisix.category.service.CategoryService;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
@@ -27,18 +25,18 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 	private final RestTemplate restTemplate = new RestTemplate();
 	private static final String URL = "http://llm-server:8000/analysis";
 
-
 	@Override
-	public List<CategoryDTO> getTopCategories(Long userId) {
+	public List<Long> getTopCategories(Long userId) {
 
 		try {
-			List<ExpenseVO> expenses = expenseService.getRecentExpenses(userId);
+			List<ExpenseVO> expenses = expenseService.getRecentExpenses(userId); // 최근 2달 소비내역
 
 			// FastAPI 서버가 요구하는 형태로 변환
 			List<Map<String, Object>> expsForAnalytics = expenses.stream()
 				.map(e -> Map.<String, Object>of(
 					"category_id", e.getCategoryId(),
-					"amount", e.getAmount()
+					"amount", e.getAmount(),
+					"expenditure_date", e.getExpenditureDate()
 				))
 				.collect(Collectors.toList());
 
@@ -54,14 +52,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 				.map(Number::longValue)
 				.toList();
 
-			List<CategoryDTO> categories = new ArrayList<>();
-			for (Long id : results) {
-				CategoryDTO dto = categoryService.getCategoryById(id);
-				if (dto != null) {
-					categories.add(dto);
-				}
-			}
-			return categories;
+			return results;
 
 		} catch (BusinessException e) {
 			log.warn("비즈니스 예외 발생: code={}, message={}", e.getCode(), e.getMessage());

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -6,7 +6,7 @@
 <mapper namespace="org.bbagisix.expense.mapper.ExpenseMapper">
     <insert id="insert" parameterType="org.bbagisix.expense.domain.ExpenseVO" useGeneratedKeys="true"
             keyProperty="expenditureId">
---          user_asset 테이블 구현 시 asset_id 추가해야함.
+        --          user_asset 테이블 구현 시 asset_id 추가해야함.
         INSERT INTO expenditure (user_id, category_id, amount, description, expenditure_date)
         VALUES (#{userId}, #{categoryId}, #{amount}, #{description}, #{expenditureDate})
     </insert>
@@ -61,7 +61,7 @@
         SELECT *
         FROM expenditure
         WHERE user_id = #{userId}
-          AND expenditure_date >= DATE_SUB(CURDATE(), INTERVAL 3 MONTH)
+          AND expenditure_date >= DATE_SUB(CURDATE(), INTERVAL 2 MONTH)
         ORDER BY expenditure_date DESC
     </select>
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#135 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
과소비 카테고리 분석 로직 수정
1. 지난 60~30일 대비 최근 30일 지출 급증한 카테고리.
2. 배달음식(1), 카페/간식(2), 쇼핑(3), 택시(4), 편의점(5), 문화(6), 술/유흥(7) 등 사치성 소비에 가중치를 둠.
3. 절대 금액이 큰 카테고리 우선.
4. 이전 지출이 없던 새로운 카테고리도 고려.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
