### PR TITLE
[FEAT] 챌린지 추천

### DIFF
--- a/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
@@ -1,5 +1,7 @@
 package org.bbagisix.challenge.controller;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.bbagisix.challenge.dto.ChallengeDTO;
 import org.bbagisix.challenge.service.ChallengeService;
@@ -32,6 +34,14 @@ public class ChallengeController {
 		} catch (NumberFormatException e) {
 			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
 		}
+	}
+
+	// 2-1. 추천 챌린지 3개 조회 API
+	@GetMapping("/recommendations")
+	public ResponseEntity<List<ChallengeDTO>> getRecommendedChallenges(Authentication authentication) {
+		CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+		List<ChallengeDTO> recommendedChallenges = challengeService.getRecommendedChallenges(currentUser.getUserId());
+		return ResponseEntity.ok(recommendedChallenges);
 	}
 
 	// 3. 챌린지 참여 API (ExpenseController 패턴 적용)

--- a/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
@@ -1,5 +1,7 @@
 package org.bbagisix.challenge.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.bbagisix.challenge.domain.ChallengeVO;
@@ -11,5 +13,6 @@ public interface ChallengeMapper {
 	boolean existsUser(@Param("userId") Long userId);
 	boolean existsUserChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 	void joinChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
-	void leaveChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);  // 새로 추가
+	void leaveChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
+	List<ChallengeVO> findChallengesByCategoryIds(@Param("categoryIds") List<Long> categoryIds, @Param("userId") Long userId);
 }

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -74,5 +74,27 @@
           AND user_id = #{userId}
     </delete>
 
-
+    <!-- 7. 추천 카테고리에 해당하는 챌린지들 조회 -->
+    <select id="findChallengesByCategoryIds" resultType="org.bbagisix.challenge.domain.ChallengeVO">
+        SELECT
+        c.challenge_id,
+        c.category_id,
+        c.title,
+        c.summary,
+        c.description
+        FROM challenge c
+        WHERE c.category_id IN
+        <foreach collection="categoryIds" item="categoryId" open="(" separator="," close=")">
+            #{categoryId}
+        </foreach>
+        AND NOT EXISTS (
+        SELECT 1
+        FROM user_challenge uc
+        WHERE uc.challenge_id = c.challenge_id
+        AND uc.user_id = #{userId}
+        AND uc.status = 'ongoing'
+        )
+        ORDER BY c.challenge_id
+        LIMIT 3
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
closed #124

## ✨ 내용
- 추천 챌린지 3개를 조회하는 API 구현
- ChallengeController, ChallengeService, ChallengeMapper 에 로직 추가
- `/api/challenges/recommend` 엔드포인트로 요청 가능
