### PR TITLE
[FEAT] 챌린지 성공/실패/진척도 계산 로직 구현

### DIFF
--- a/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
@@ -2,7 +2,6 @@ package org.bbagisix.challenge.controller;
 
 import java.util.List;
 
-import lombok.RequiredArgsConstructor;
 import org.bbagisix.challenge.dto.ChallengeDTO;
 import org.bbagisix.challenge.dto.ChallengeProgressDTO;
 import org.bbagisix.challenge.service.ChallengeService;
@@ -11,7 +10,13 @@ import org.bbagisix.exception.ErrorCode;
 import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/challenges")
@@ -40,7 +45,7 @@ public class ChallengeController {
 	// 2-1. 추천 챌린지 3개 조회 API
 	@GetMapping("/recommendations")
 	public ResponseEntity<List<ChallengeDTO>> getRecommendedChallenges(Authentication authentication) {
-		CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
 		List<ChallengeDTO> recommendedChallenges = challengeService.getRecommendedChallenges(currentUser.getUserId());
 		return ResponseEntity.ok(recommendedChallenges);
 	}
@@ -69,7 +74,7 @@ public class ChallengeController {
 			Long parsedChallengeId = Long.parseLong(challengeId);
 
 			// ExpenseController와 동일한 패턴으로 사용자 정보 추출
-			CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+			CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
 
 			challengeService.joinChallenge(parsedChallengeId, currentUser.getUserId());
 			return ResponseEntity.ok("챌린지 참여가 완료되었습니다.");

--- a/src/main/java/org/bbagisix/challenge/domain/UserChallengeVO.java
+++ b/src/main/java/org/bbagisix/challenge/domain/UserChallengeVO.java
@@ -9,13 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@Setter
 @ToString
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)

--- a/src/main/java/org/bbagisix/challenge/domain/UserChallengeVO.java
+++ b/src/main/java/org/bbagisix/challenge/domain/UserChallengeVO.java
@@ -1,0 +1,33 @@
+package org.bbagisix.challenge.domain;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class UserChallengeVO {
+	private Long userChallengeId;
+	private Long userId;
+	private Long challengeId;
+	private String status;
+	private Long period;
+	private Long progress;
+	private Date startDate;
+	private Date endDate;
+	private Long saving;
+	private Boolean isActive;
+}

--- a/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
@@ -5,19 +5,32 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.bbagisix.challenge.domain.ChallengeVO;
+import org.bbagisix.challenge.domain.UserChallengeVO;
 import org.bbagisix.challenge.dto.ChallengeProgressDTO;
 
 @Mapper
 public interface ChallengeMapper {
 	ChallengeVO findByChallengeId(@Param("challengeId") Long challengeId);
+
 	boolean hasActiveChallenge(@Param("userId") Long userId);
+
 	boolean existsUser(@Param("userId") Long userId);
+
 	boolean existsUserChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
+
 	void joinChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 
 	// 추천 카테고리에 해당하는 챌린지들 조회
-	List<ChallengeVO> findChallengesByCategoryIds(@Param("categoryIds") List<Long> categoryIds, @Param("userId") Long userId);
+	List<ChallengeVO> findChallengesByCategoryIds(@Param("categoryIds") List<Long> categoryIds,
+		@Param("userId") Long userId);
 
 	// 사용자 챌린지 진척도 조회
 	ChallengeProgressDTO getChallengeProgress(@Param("userId") Long userId);
+
+	List<UserChallengeVO> getOngoingChallenges();
+
+	Long getCategoryByChallengeId(Long challengeId);
+
+	void updateChallenge(UserChallengeVO userChallenge);
+
 }

--- a/src/main/java/org/bbagisix/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/org/bbagisix/challenge/scheduler/ChallengeScheduler.java
@@ -1,0 +1,19 @@
+package org.bbagisix.challenge.scheduler;
+
+import org.bbagisix.challenge.service.ChallengeService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChallengeScheduler {
+	private final ChallengeService challengeService;
+
+	@Scheduled(cron = "0 59 23 * * *")
+	public void DailyCheck() {
+		challengeService.dailyCheck();
+	}
+
+}

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -2,9 +2,12 @@ package org.bbagisix.expense.mapper;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Mapper;
 import org.bbagisix.expense.domain.ExpenseVO;
 
+@Mapper
 public interface ExpenseMapper {
+	
 	void insert(ExpenseVO expense);
 
 	ExpenseVO findById(Long expenditureId);
@@ -16,4 +19,6 @@ public interface ExpenseMapper {
 	int delete(Long expenditureId, Long userId);
 
 	List<ExpenseVO> getRecentExpenses(Long userId);
+
+	List<Long> getTodayExpenseCategories(Long userId);
 }

--- a/src/main/java/org/bbagisix/saving/mapper/SavingMapper.java
+++ b/src/main/java/org/bbagisix/saving/mapper/SavingMapper.java
@@ -2,7 +2,7 @@ package org.bbagisix.saving.mapper;
 
 import java.util.List;
 
-import org.bbagisix.saving.domain.UserChallengeVO;
+import org.bbagisix.challenge.domain.UserChallengeVO;
 
 public interface SavingMapper {
 	List<UserChallengeVO> getSavingHistory(Long userId);

--- a/src/main/java/org/bbagisix/saving/service/SavingService.java
+++ b/src/main/java/org/bbagisix/saving/service/SavingService.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bbagisix.challenge.domain.ChallengeVO;
+import org.bbagisix.challenge.domain.UserChallengeVO;
 import org.bbagisix.challenge.mapper.ChallengeMapper;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
-import org.bbagisix.saving.domain.UserChallengeVO;
 import org.bbagisix.saving.dto.SavingDTO;
 import org.bbagisix.saving.mapper.SavingMapper;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -7,64 +7,54 @@
 
     <!-- 1. 챌린지 ID로 단일 챌린지 조회 -->
     <select id="findByChallengeId" resultType="org.bbagisix.challenge.domain.ChallengeVO">
-        SELECT
-            challenge_id,
-            category_id,
-            title,
-            summary,
-            description
+        SELECT challenge_id,
+               category_id,
+               title,
+               summary,
+               description
         FROM challenge
         WHERE challenge_id = #{challengeId}
     </select>
 
     <!-- 2. 유저가 해당 챌린지에 참여 중인지 확인 -->
     <select id="existsUserChallenge" resultType="boolean">
-        SELECT EXISTS (
-            SELECT 1
-            FROM user_challenge
-            WHERE challenge_id = #{challengeId}
-              AND user_id = #{userId}
-        )
+        SELECT EXISTS (SELECT 1
+                       FROM user_challenge
+                       WHERE challenge_id = #{challengeId}
+                         AND user_id = #{userId})
     </select>
 
     <!-- 3. 유저가 어떤 챌린지든 참여 중인지 확인 -->
     <select id="hasActiveChallenge" resultType="boolean">
-        SELECT EXISTS (
-            SELECT 1
-            FROM user_challenge
-            WHERE user_id = #{userId}
-              AND status = 'ongoing'
-        )
+        SELECT EXISTS (SELECT 1
+                       FROM user_challenge
+                       WHERE user_id = #{userId}
+                         AND status = 'ongoing')
     </select>
 
     <!-- 4. 사용자 존재 여부 확인 -->
     <select id="existsUser" resultType="boolean">
-        SELECT EXISTS (
-            SELECT 1
-            FROM user
-            WHERE user_id = #{userId}
-        )
+        SELECT EXISTS (SELECT 1
+                       FROM user
+                       WHERE user_id = #{userId})
     </select>
 
     <!-- 5. 챌린지 참여 -->
     <insert id="joinChallenge">
-        INSERT INTO user_challenge (
-            user_id,
-            challenge_id,
-            status,
-            period,
-            progress,
-            start_date,
-            end_date
-        ) VALUES (
-                     #{userId},
-                     #{challengeId},
-                     'ongoing',
-                     30,
-                     0,
-                     NOW(),
-                     DATE_ADD(NOW(), INTERVAL 30 DAY)
-                 )
+        INSERT INTO user_challenge (user_id,
+                                    challenge_id,
+                                    status,
+                                    period,
+                                    progress,
+                                    start_date,
+                                    end_date)
+        VALUES (#{userId},
+                #{challengeId},
+                'ongoing',
+                30,
+                0,
+                NOW(),
+                DATE_ADD(NOW(), INTERVAL 30 DAY))
     </insert>
 
     <!-- 7. 추천 카테고리에 해당하는 챌린지들 조회 -->
@@ -93,18 +83,16 @@
 
     <!-- 8. 사용자 챌린지 진척도 조회 -->
     <select id="getChallengeProgress" resultType="org.bbagisix.challenge.dto.ChallengeProgressDTO">
-        SELECT
-            uc.challenge_id,
-            (SELECT c.title FROM challenge c WHERE c.challenge_id = uc.challenge_id) as title,
-            uc.period,
-            uc.status,
-            uc.progress,
-            uc.saving,
-            uc.is_active
+        SELECT uc.challenge_id,
+               (SELECT c.title FROM challenge c WHERE c.challenge_id = uc.challenge_id) as title,
+               uc.period,
+               uc.status,
+               uc.progress,
+               uc.saving,
+               uc.is_active
         FROM user_challenge uc
         WHERE uc.user_id = #{userId}
-          AND uc.is_active = true
-        LIMIT 1
+          AND uc.is_active = true LIMIT 1
     </select>
 
     <!--    진행중인 유저챌린지 조회-->
@@ -125,7 +113,8 @@
     <update id="updateChallenge" parameterType="org.bbagisix.challenge.domain.UserChallengeVO">
         update user_challenge
         set status=#{status},
-            progress=#{progress}
+            progress=#{progress},
+            end_date=#{endDate}
         where user_challenge_id = #{userChallengeId}
     </update>
 

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -106,4 +106,27 @@
           AND uc.is_active = true
         LIMIT 1
     </select>
+
+    <!--    진행중인 유저챌린지 조회-->
+    <select id="getOngoingChallenges" resultType="org.bbagisix.challenge.domain.UserChallengeVO">
+        select *
+        from user_challenge
+        where status = 'ongoing'
+    </select>
+
+    <!--    챌린지 아이디로 카테고리 아이디 가져오기-->
+    <select id="getCategoryByChallengeId" parameterType="long" resultType="long">
+        select category_id
+        from challenge
+        where challenge_id = #{challengeId}
+    </select>
+
+    <!--    챌린지 성공/실패여부 업데이트-->
+    <update id="updateChallenge" parameterType="org.bbagisix.challenge.domain.UserChallengeVO">
+        update user_challenge
+        set status=#{status},
+            progress=#{progress}
+        where user_challenge_id = #{userChallengeId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -65,4 +65,11 @@
         ORDER BY expenditure_date DESC
     </select>
 
+    <select id="getTodayExpenseCategories" parameterType="long" resultType="long">
+        SELECT category_id
+        FROM expenditure
+        WHERE user_id = #{userId}
+          AND DATE (expenditure_date)=CURDATE()
+    </select>
+
 </mapper>

--- a/src/main/resources/mappers/saving/SavingMapper.xml
+++ b/src/main/resources/mappers/saving/SavingMapper.xml
@@ -4,16 +4,16 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.bbagisix.saving.mapper.SavingMapper">
-    <select id="getSavingHistory" parameterType="long" resultType="org.bbagisix.saving.domain.UserChallengeVO">
+    <select id="getSavingHistory" parameterType="long" resultType="org.bbagisix.challenge.domain.UserChallengeVO">
         select *
         from user_challenge
         where user_id = #{userId}
-          and status = "completed"
+          and status = 'completed'
     </select>
     <select id="getTotalSaving" parameterType="long" resultType="long">
         select balance
         from user_asset
         where user_id = #{user_id}
-          and status = "sub"
+          and status = 'sub'
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#137 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- dailyCheck에서 주요 로직을 담당합니다.
(금지 챌린지의 카테고리가 있는지 확인한 뒤 성공/실패 처리 및 진척도 계산)
- ChallengeScheduler에서 위 메서드를 매일 23시 59분마다 실행합니다.
- challenge와 expense 에 위 메서드에 필요한 매퍼들이 추가되었습니다.
- 테스트는 로컬환경에서 진행한거라 따로 업로드 x

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
