### PR TITLE
[FEAT] 적금 상품 데이터 수집을 위한 VO, DTO, Mapper 구현

### DIFF
--- a/src/main/java/org/bbagisix/finproduct/domain/SavingBaseVO.java
+++ b/src/main/java/org/bbagisix/finproduct/domain/SavingBaseVO.java
@@ -1,0 +1,29 @@
+package org.bbagisix.finproduct.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.sql.Timestamp;
+
+@Getter
+@ToString
+public class SavingBaseVO {
+    private Long savingBaseId;
+    private String dclsMonth;
+    private String finCoNo;
+    private String finPrdtCd;
+    private String korCoNm;
+    private String finPrdtNm;
+    private String joinWay;
+    private String mtrtInt;
+    private String spclCnd;
+    private String joinDeny;
+    private String joinMember;
+    private String etcNote;
+    private Integer maxLimit;
+    private String dclsStrtDay;
+    private String dclsEndDay;
+    private String finCoSubmDay;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/src/main/java/org/bbagisix/finproduct/domain/SavingBaseVO.java
+++ b/src/main/java/org/bbagisix/finproduct/domain/SavingBaseVO.java
@@ -1,12 +1,18 @@
 package org.bbagisix.finproduct.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.sql.Timestamp;
 
 @Getter
 @ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SavingBaseVO {
     private Long savingBaseId;
     private String dclsMonth;

--- a/src/main/java/org/bbagisix/finproduct/domain/SavingOptionVO.java
+++ b/src/main/java/org/bbagisix/finproduct/domain/SavingOptionVO.java
@@ -1,6 +1,9 @@
 package org.bbagisix.finproduct.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.math.BigDecimal;
@@ -8,6 +11,9 @@ import java.sql.Timestamp;
 
 @Getter
 @ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SavingOptionVO {
     private Long savingOptionId;
     private Long savingBaseId; // Foreign Key

--- a/src/main/java/org/bbagisix/finproduct/domain/SavingOptionVO.java
+++ b/src/main/java/org/bbagisix/finproduct/domain/SavingOptionVO.java
@@ -1,0 +1,26 @@
+package org.bbagisix.finproduct.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+@Getter
+@ToString
+public class SavingOptionVO {
+    private Long savingOptionId;
+    private Long savingBaseId; // Foreign Key
+    private String dclsMonth;
+    private String finCoNo;
+    private String finPrdtCd;
+    private String intrRateType;
+    private String intrRateTypeNm;
+    private String rsrvType;
+    private String rsrvTypeNm;
+    private String saveTrm;
+    private BigDecimal intrRate;
+    private BigDecimal intrRate2;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
@@ -1,21 +1,30 @@
 package org.bbagisix.finproduct.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class FssApiResponseDTO {
 
     @JsonProperty("result")
-    private ResultDto result;
+    private ResultDTO result;
 
     @Getter
     @Setter
-    public static class ResultDto {
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultDTO {
         @JsonProperty("prdt_div")
         private String prdtDiv;
 

--- a/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
@@ -1,0 +1,43 @@
+package org.bbagisix.finproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class FssApiResponseDTO {
+
+    @JsonProperty("result")
+    private ResultDto result;
+
+    @Getter
+    @Setter
+    public static class ResultDto {
+        @JsonProperty("prdt_div")
+        private String prdtDiv;
+
+        @JsonProperty("total_count")
+        private int totalCount;
+
+        @JsonProperty("max_page_no")
+        private int maxPageNo;
+
+        @JsonProperty("now_page_no")
+        private int nowPageNo;
+
+        @JsonProperty("err_cd")
+        private String errCd;
+
+        @JsonProperty("err_msg")
+        private String errMsg;
+
+        @JsonProperty("baseList")
+        private List<ProductBaseDto> baseList;
+
+        @JsonProperty("optionList")
+        private List<ProductOptionDto> optionList;
+    }
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/FssApiResponseDTO.java
@@ -35,9 +35,9 @@ public class FssApiResponseDTO {
         private String errMsg;
 
         @JsonProperty("baseList")
-        private List<ProductBaseDto> baseList;
+        private List<ProductBaseDTO> baseList;
 
         @JsonProperty("optionList")
-        private List<ProductOptionDto> optionList;
+        private List<ProductOptionDTO> optionList;
     }
 }

--- a/src/main/java/org/bbagisix/finproduct/dto/ProductBaseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/ProductBaseDTO.java
@@ -1,11 +1,17 @@
 package org.bbagisix.finproduct.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductBaseDTO {
 
     @JsonProperty("dcls_month")

--- a/src/main/java/org/bbagisix/finproduct/dto/ProductBaseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/ProductBaseDTO.java
@@ -1,0 +1,55 @@
+package org.bbagisix.finproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProductBaseDTO {
+
+    @JsonProperty("dcls_month")
+    private String dclsMonth;
+
+    @JsonProperty("fin_co_no")
+    private String finCoNo;
+
+    @JsonProperty("fin_prdt_cd")
+    private String finPrdtCd;
+
+    @JsonProperty("kor_co_nm")
+    private String korCoNm;
+
+    @JsonProperty("fin_prdt_nm")
+    private String finPrdtNm;
+
+    @JsonProperty("join_way")
+    private String joinWay;
+
+    @JsonProperty("mtrt_int")
+    private String mtrtInt;
+
+    @JsonProperty("spcl_cnd")
+    private String spclCnd;
+
+    @JsonProperty("join_deny")
+    private String joinDeny;
+
+    @JsonProperty("join_member")
+    private String joinMember;
+
+    @JsonProperty("etc_note")
+    private String etcNote;
+
+    @JsonProperty("max_limit")
+    private Integer maxLimit;
+
+    @JsonProperty("dcls_strt_day")
+    private String dclsStrtDay;
+
+    @JsonProperty("dcls_end_day")
+    private String dclsEndDay;
+
+    @JsonProperty("fin_co_subm_day")
+    private String finCoSubmDay;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/ProductOptionDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/ProductOptionDTO.java
@@ -1,0 +1,42 @@
+package org.bbagisix.finproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+public class ProductOptionDto {
+
+    @JsonProperty("dcls_month")
+    private String dclsMonth;
+
+    @JsonProperty("fin_co_no")
+    private String finCoNo;
+
+    @JsonProperty("fin_prdt_cd")
+    private String finPrdtCd;
+
+    @JsonProperty("intr_rate_type")
+    private String intrRateType;
+
+    @JsonProperty("intr_rate_type_nm")
+    private String intrRateTypeNm;
+
+    @JsonProperty("rsrv_type")
+    private String rsrvType;
+
+    @JsonProperty("rsrv_type_nm")
+    private String rsrvTypeNm;
+
+    @JsonProperty("save_trm")
+    private String saveTrm;
+
+    @JsonProperty("intr_rate")
+    private BigDecimal intrRate;
+
+    @JsonProperty("intr_rate2")
+    private BigDecimal intrRate2;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/ProductOptionDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/ProductOptionDTO.java
@@ -1,14 +1,20 @@
 package org.bbagisix.finproduct.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Getter
 @Setter
-public class ProductOptionDto {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductOptionDTO {
 
     @JsonProperty("dcls_month")
     private String dclsMonth;

--- a/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
@@ -1,0 +1,24 @@
+package org.bbagisix.finproduct.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@Getter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendedSavingDTO {
+    private String finPrdtCd;      // 금융상품 코드
+    private String korCoNm;        // 금융회사 명
+    private String finPrdtNm;      // 금융상품 명
+    private String spclCnd;        // 우대 조건
+    private String joinMember;     // 가입 대상
+    private BigDecimal intrRate;       // 저축 금리
+    private BigDecimal intrRate2;      // 최고 우대금리
+}

--- a/src/main/java/org/bbagisix/finproduct/mapper/FinProductMapper.java
+++ b/src/main/java/org/bbagisix/finproduct/mapper/FinProductMapper.java
@@ -1,0 +1,17 @@
+package org.bbagisix.finproduct.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.bbagisix.finproduct.domain.SavingBaseVO;
+import org.bbagisix.finproduct.domain.SavingOptionVO;
+
+@Mapper
+public interface FinProductMapper {
+
+    void insertOrUpdateBase(SavingBaseVO baseVO);
+
+    void insertOrUpdateOption(SavingOptionVO optionVO);
+
+    // 복합 키(fin_co_no, fin_prdt_cd, dcls_month)를 기준으로 saving_base 테이블의 PK를 조회
+    // 옵션 정보를 saving_option 테이블에 저장할 때, 방금 알아낸 `saving_base_id` 값을 `saving_base_id` 컬럼에 넣음
+    Long findSavingBaseId(SavingBaseVO baseVO);
+}

--- a/src/main/resources/mappers/finproduct/FinProductMapper.xml
+++ b/src/main/resources/mappers/finproduct/FinProductMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bbagisix.finproduct.mapper.FinProductMapper">
+
+    <insert id="insertOrUpdateBase" parameterType="org.bbagisix.finproduct.domain.SavingBaseVO">
+        INSERT INTO saving_base (
+            dcls_month, fin_co_no, fin_prdt_cd, kor_co_nm, fin_prdt_nm, 
+            join_way, mtrt_int, spcl_cnd, join_deny, join_member, 
+            etc_note, max_limit, dcls_strt_day, dcls_end_day, fin_co_subm_day
+        )
+        VALUES (
+            #{dclsMonth}, #{finCoNo}, #{finPrdtCd}, #{korCoNm}, #{finPrdtNm}, 
+            #{joinWay}, #{mtrtInt}, #{spclCnd}, #{joinDeny}, #{joinMember}, 
+            #{etcNote}, #{maxLimit}, #{dclsStrtDay}, #{dclsEndDay}, #{finCoSubmDay}
+        )
+        ON DUPLICATE KEY UPDATE
+            kor_co_nm = VALUES(kor_co_nm),
+            fin_prdt_nm = VALUES(fin_prdt_nm),
+            join_way = VALUES(join_way),
+            mtrt_int = VALUES(mtrt_int),
+            spcl_cnd = VALUES(spcl_cnd),
+            join_deny = VALUES(join_deny),
+            join_member = VALUES(join_member),
+            etc_note = VALUES(etc_note),
+            max_limit = VALUES(max_limit),
+            dcls_strt_day = VALUES(dcls_strt_day),
+            dcls_end_day = VALUES(dcls_end_day),
+            fin_co_subm_day = VALUES(fin_co_subm_day);
+    </insert>
+
+    <insert id="insertOrUpdateOption" parameterType="org.bbagisix.finproduct.domain.SavingOptionVO">
+        INSERT INTO saving_option (
+            saving_base_id, dcls_month, fin_co_no, fin_prdt_cd, intr_rate_type, 
+            intr_rate_type_nm, rsrv_type, rsrv_type_nm, save_trm, intr_rate, intr_rate2
+        )
+        VALUES (
+            #{savingBaseId}, #{dclsMonth}, #{finCoNo}, #{finPrdtCd}, #{intrRateType}, 
+            #{intrRateTypeNm}, #{rsrvType}, #{rsrvTypeNm}, #{saveTrm}, #{intrRate}, #{intrRate2}
+        )
+        ON DUPLICATE KEY UPDATE
+            intr_rate_type = VALUES(intr_rate_type),
+            intr_rate_type_nm = VALUES(intr_rate_type_nm),
+            intr_rate = VALUES(intr_rate),
+            intr_rate2 = VALUES(intr_rate2);
+    </insert>
+
+    <select id="findSavingBaseId" parameterType="org.bbagisix.finproduct.domain.SavingBaseVO" resultType="long">
+        SELECT saving_base_id
+        FROM saving_base
+        WHERE fin_co_no = #{finCoNo}
+          AND fin_prdt_cd = #{finPrdtCd}
+          AND dcls_month = #{dclsMonth};
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌 관련 이슈
Closed #132 

## ✨ 내용
금융감독원 API를 통해 적금 상품 정보를 수집, 이를 DB에 저장하기 위한 기반을 구현.
- DB 스키마에 맞춰 VO와 DTO 클래스 설계
- MyBatis Mapper 인터페이스와 XML 구현. ON DUPLICATE KEY UPDATE 쿼리를 통해, 1. 데이터가 없을 경우 2. 새로 추가하고 있을 경우 최신 정보로 자동 갱신하는 로직 구현 (스케줄러가 반복적으로 실행되더라도 데이터의 최신성을 유지하고 중복 오류를 방지하는 핵심적인 부분)