### PR TITLE
[FEAT] 챌린지 기준금액(saving) 계산 로직

### DIFF
--- a/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
@@ -54,29 +54,27 @@ public class ChallengeController {
 	// ChallengeController.java에 추가
 	@GetMapping("/progress")
 	public ResponseEntity<ChallengeProgressDTO> getChallengeProgress(Authentication authentication) {
-		CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
 		ChallengeProgressDTO result = challengeService.getChallengeProgress(currentUser.getUserId());
 		return ResponseEntity.ok(result);
 	}
 
 	// 3. 챌린지 참여 API (ExpenseController 패턴 적용)
-	@PostMapping("/{challengeId}/join")
+	@PostMapping("/join/{challengeId}/{period}")
 	public ResponseEntity<String> joinChallenge(
-		@PathVariable String challengeId,
+		@PathVariable Long challengeId,
+		@PathVariable Long period,
 		Authentication authentication) {
 
 		// challengeId 유효성 검사
-		if (challengeId == null || challengeId.trim().isEmpty() || challengeId.equalsIgnoreCase("null")) {
+		if (challengeId == null) {
 			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
 		}
 
 		try {
-			Long parsedChallengeId = Long.parseLong(challengeId);
-
 			// ExpenseController와 동일한 패턴으로 사용자 정보 추출
 			CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
-
-			challengeService.joinChallenge(parsedChallengeId, currentUser.getUserId());
+			challengeService.joinChallenge(currentUser.getUserId(), challengeId, period);
 			return ResponseEntity.ok("챌린지 참여가 완료되었습니다.");
 
 		} catch (NumberFormatException e) {

--- a/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
@@ -18,7 +18,7 @@ public interface ChallengeMapper {
 
 	boolean existsUserChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 
-	void joinChallenge(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
+	void joinChallenge(UserChallengeVO userChallenge);
 
 	// 추천 카테고리에 해당하는 챌린지들 조회
 	List<ChallengeVO> findChallengesByCategoryIds(@Param("categoryIds") List<Long> categoryIds,

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -3,11 +3,12 @@ package org.bbagisix.expense.mapper;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.bbagisix.expense.domain.ExpenseVO;
 
 @Mapper
 public interface ExpenseMapper {
-	
+
 	void insert(ExpenseVO expense);
 
 	ExpenseVO findById(Long expenditureId);
@@ -21,4 +22,8 @@ public interface ExpenseMapper {
 	List<ExpenseVO> getRecentExpenses(Long userId);
 
 	List<Long> getTodayExpenseCategories(Long userId);
+
+	Long getSumOfPeriodExpenses(@Param("userId") Long userId,
+		@Param("categoryId") Long categoryId,
+		@Param("period") Long period);
 }

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -58,7 +58,7 @@
                 NOW(),
                 DATE_ADD(NOW(), INTERVAL #{period} DAY),
                 #{saving},
-                false)
+                0)
     </insert>
 
     <!-- 7. 추천 카테고리에 해당하는 챌린지들 조회 -->

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -40,21 +40,25 @@
     </select>
 
     <!-- 5. 챌린지 참여 -->
-    <insert id="joinChallenge">
+    <insert id="joinChallenge" parameterType="org.bbagisix.challenge.domain.UserChallengeVO">
         INSERT INTO user_challenge (user_id,
                                     challenge_id,
                                     status,
                                     period,
                                     progress,
                                     start_date,
-                                    end_date)
+                                    end_date,
+                                    saving,
+                                    is_active)
         VALUES (#{userId},
                 #{challengeId},
                 'ongoing',
-                30,
+                #{period},
                 0,
                 NOW(),
-                DATE_ADD(NOW(), INTERVAL 30 DAY))
+                DATE_ADD(NOW(), INTERVAL #{period} DAY),
+                #{saving},
+                false)
     </insert>
 
     <!-- 7. 추천 카테고리에 해당하는 챌린지들 조회 -->

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -72,4 +72,13 @@
           AND DATE (expenditure_date)=CURDATE()
     </select>
 
+    <select id="getSumOfPeriodExpenses" resultType="long">
+        SELECT SUM(amount)
+        FROM expenditure
+        WHERE user_id = #{userId}
+          AND category_id = #{categoryId}
+          AND expenditure_date
+            BETWEEN DATE_SUB(CURDATE() - INTERVAL 1 DAY, INTERVAL #{period} DAY)
+            AND (CURDATE() - INTERVAL 1 DAY)
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#154 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
수정 사항
- mapper에서 30일로 하드코딩된 부분을 수정하였습니다
- controller에서 period 값을 pathvariable로 받아오도록 수정했기 때문에, 
api 주소가 /api/challenges/join/{challenge_id}/{period} 이렇게 변경되었습니다.

추가사항(계산 로직)
- 서비스 joinChallenge에 챌린지 기준금액(saving) 계산 로직을 추가했습니다.
- 기준금액이란 챌린지 하루 성공시마다 아낀 금액에 증액되는 금액으로, userChallenge의 saving 필드에 해당합니다.
(기준금액='이전기간'동안 해당 카테고리에 대한 총 소비액 / 챌린지 진행기간,
이전기간 = (챌린지시작일 -1) ~ (챌린지 시작일 - 챌린지 진행기간))

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
