### PR TITLE
[REFACTOR]ExpenseService와 AssetService 중복 로직 제거 및 asset 연동 완성

### DIFF
--- a/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
+++ b/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
@@ -18,8 +18,6 @@ public interface AssetMapper {
 
 	int deleteExpensesByUserId(Long userId);
 
-	int insertExpenses(List<ExpenseVO> expenseVO);
-
 	// 모든 main 계좌 조회
 	List<AssetVO> selectAllMainAssets();
 

--- a/src/main/java/org/bbagisix/asset/service/AssetService.java
+++ b/src/main/java/org/bbagisix/asset/service/AssetService.java
@@ -191,7 +191,7 @@ public class AssetService {
 				log.info("llm err.." + e.getMessage());
 			}
 			// log.info("llm end.." + expenseVOList.stream().toList());
-			int insertedCount = assetMapper.insertExpenses(expenseVOList);
+			int insertedCount = expenseMapper.insertExpenses(expenseVOList);
 			if (insertedCount != expenseVOList.size()) {
 				throw new BusinessException(ErrorCode.TRANSACTION_FAIL,
 					"일부 거래내역 저장에 실패했습니다. 예상: " + expenseVOList.size() + ", 실제: " + insertedCount);

--- a/src/main/java/org/bbagisix/codef/service/CodefSchedulerService.java
+++ b/src/main/java/org/bbagisix/codef/service/CodefSchedulerService.java
@@ -97,7 +97,7 @@ public class CodefSchedulerService {
 
 		if (!newTransactions.isEmpty()) {
 			newTransactions = classifyService.classify(newTransactions);
-			int insertedCount = assetMapper.insertExpenses(newTransactions);
+			int insertedCount = expenseMapper.insertExpenses(newTransactions);
 			log.info(" 👉 [ user ID : {} ] update new transactions... : {} ", asset.getUserId(), newTransactions.size());
 		}
 	}

--- a/src/main/java/org/bbagisix/expense/dto/ExpenseDTO.java
+++ b/src/main/java/org/bbagisix/expense/dto/ExpenseDTO.java
@@ -22,9 +22,8 @@ public class ExpenseDTO {
 	private Long expenditureId;
 	private String categoryName;
 	private String categoryIcon;
-	// asset 패키지 완성시 연동
-	// private String assetName;
-	// private String bankName;
+	private String assetName;
+	private String bankName;
 	private Date createdAt;
 	private Date updatedAt;
 

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -26,4 +26,6 @@ public interface ExpenseMapper {
 	Long getSumOfPeriodExpenses(@Param("userId") Long userId,
 		@Param("categoryId") Long categoryId,
 		@Param("period") Long period);
+
+	int insertExpenses(List<ExpenseVO> expenses);
 }

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -3,6 +3,8 @@ package org.bbagisix.expense.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.bbagisix.asset.domain.AssetVO;
+import org.bbagisix.asset.mapper.AssetMapper;
 import org.bbagisix.category.domain.CategoryVO;
 import org.bbagisix.category.mapper.CategoryMapper;
 import org.bbagisix.expense.domain.ExpenseVO;
@@ -21,8 +23,7 @@ import lombok.extern.log4j.Log4j2;
 public class ExpenseServiceImpl implements ExpenseService {
 	private final ExpenseMapper expenseMapper;
 	private final CategoryMapper categoryMapper;
-	// asset 패키지 완성 시 연동
-	// private final AssetMapper assetMapper;
+	private final AssetMapper assetMapper;
 
 	@Override
 	public ExpenseDTO createExpense(ExpenseDTO expenseDTO) {
@@ -82,7 +83,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			}
 
 			vo.setCategoryId(expenseDTO.getCategoryId());
-			vo.setAssetId(null); // asset 패키지 구현 전까지 null 처리
+			vo.setAssetId(expenseDTO.getAssetId());
 			vo.setAmount(expenseDTO.getAmount());
 			vo.setDescription(expenseDTO.getDescription());
 			vo.setExpenditureDate(expenseDTO.getExpenditureDate());
@@ -160,7 +161,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			}
 
 			vo.setCategoryId(expenseDTO.getCategoryId());
-			vo.setAssetId(null); // asset 패키지 구현 전까지 null 처리
+			vo.setAssetId(expenseDTO.getAssetId());
 			vo.setAmount(expenseDTO.getAmount());
 			vo.setDescription(expenseDTO.getDescription());
 			vo.setExpenditureDate(expenseDTO.getExpenditureDate());
@@ -216,15 +217,16 @@ public class ExpenseServiceImpl implements ExpenseService {
 			}
 		}
 
-		/* asset 패키지 완성 시 연동
-		* if (vo.getAssetId() != null) {
-			AssetVO assetVO = assetMapper.findById(vo.getAssetId());
+		if (vo.getAssetId() != null) {
+			AssetVO assetVO = assetMapper.selectAssetByUserIdAndStatus(vo.getUserId(), "main");
+			if (assetVO == null) {
+				assetVO = assetMapper.selectAssetByUserIdAndStatus(vo.getUserId(), "sub");
+			}
 			if (assetVO != null) {
 				dto.setAssetName(assetVO.getAssetName());
 				dto.setBankName(assetVO.getBankName());
 			}
 		}
-		* */
 		return dto;
 	}
 }

--- a/src/main/resources/mappers/asset/AssetMapper.xml
+++ b/src/main/resources/mappers/asset/AssetMapper.xml
@@ -87,29 +87,6 @@
         )
     </delete>
 
-    <insert id="insertExpenses" parameterType="java.util.List">
-        INSERT INTO expenditure (
-        user_id,
-        asset_id,
-        category_id,
-        amount,
-        description,
-        expenditure_date,
-        created_at
-        ) VALUES
-        <foreach collection="list" item="expense" separator=",">
-            (
-            #{expense.userId},
-            #{expense.assetId},
-            #{expense.categoryId},
-            #{expense.amount},
-            #{expense.description},
-            #{expense.expenditureDate},
-            NOW()
-            )
-        </foreach>
-    </insert>
-
     <!-- 모든 main 계좌 조회 -->
     <select id="selectAllMainAssets" resultMap="AssetResultMap">
         SELECT

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -81,4 +81,27 @@
             BETWEEN DATE_SUB(CURDATE() - INTERVAL 1 DAY, INTERVAL #{period} DAY)
             AND (CURDATE() - INTERVAL 1 DAY)
     </select>
+
+    <insert id="insertExpenses" parameterType="java.util.List">
+        INSERT INTO expenditure (
+            user_id,
+            asset_id,
+            category_id,
+            amount,
+            description,
+            expenditure_date,
+            created_at
+        ) VALUES
+        <foreach collection="list" item="expense" separator=",">
+            (
+                #{expense.userId},
+                #{expense.assetId},
+                #{expense.categoryId},
+                #{expense.amount},
+                #{expense.description},
+                #{expense.expenditureDate},
+                NOW()
+            )
+        </foreach>
+    </insert>
 </mapper>

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -6,16 +6,15 @@
 <mapper namespace="org.bbagisix.expense.mapper.ExpenseMapper">
     <insert id="insert" parameterType="org.bbagisix.expense.domain.ExpenseVO" useGeneratedKeys="true"
             keyProperty="expenditureId">
-        --          user_asset 테이블 구현 시 asset_id 추가해야함.
-        INSERT INTO expenditure (user_id, category_id, amount, description, expenditure_date)
-        VALUES (#{userId}, #{categoryId}, #{amount}, #{description}, #{expenditureDate})
+        INSERT INTO expenditure (user_id, category_id, asset_id, amount, description, expenditure_date)
+        VALUES (#{userId}, #{categoryId}, #{assetId}, #{amount}, #{description}, #{expenditureDate})
     </insert>
 
     <select id="findById" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
         SELECT expenditure_id,
                user_id,
                category_id,
---                asset_id,
+               asset_id,
                amount,
                description,
                expenditure_date,
@@ -29,7 +28,7 @@
         SELECT expenditure_id,
                user_id,
                category_id,
---                asset_id,
+               asset_id,
                amount,
                description,
                expenditure_date,
@@ -43,6 +42,7 @@
     <update id="update" parameterType="org.bbagisix.expense.domain.ExpenseVO">
         UPDATE expenditure
         SET category_id      = #{categoryId},
+            asset_id         = #{assetId},
             amount           = #{amount},
             description      = #{description},
             expenditure_date = #{expenditureDate}


### PR DESCRIPTION
## 📌 관련 이슈
closed #161 

## ✨ 내용
asset 패키지 완성에 따라 ExpenseService와 AssetService 간 중복 로직 제거, 주석 처리된 asset 연동 코드를 활성화

  1: 중복 로직 통합

  -  ExpenseMapper에 insertExpenses 메서드 추가
  -  ExpenseMapper.xml에 배치 INSERT 쿼리 구현
  - AssetService에서 ExpenseMapper 사용하도록 변경
  - AssetMapper에서 중복 메서드/쿼리 제거

  2: Asset 연동 활성화

  -  ExpenseServiceImpl에서 AssetMapper 의존성 주입 활성화
  -  assetId null 강제 처리 제거
  -  voToDto에서 asset 정보 연동 로직 활성화

  3: DB 쿼리 및 DTO 정리

  -  ExpenseMapper.xml에서 asset_id 컬럼 주석 해제
  -  ExpenseDTO에서 assetName, bankName 필드 활성화
  -  UPDATE 쿼리에 asset_id 추가

