### PR TITLE
[FEAT] 티어 승급 API

### DIFF
--- a/src/main/java/org/bbagisix/reward/controller/RewardController.java
+++ b/src/main/java/org/bbagisix/reward/controller/RewardController.java
@@ -1,4 +1,0 @@
-package org.bbagisix.reward.controller;
-
-public class RewardController {
-}

--- a/src/main/java/org/bbagisix/reward/domain/RewardVO.java
+++ b/src/main/java/org/bbagisix/reward/domain/RewardVO.java
@@ -1,4 +1,0 @@
-package org.bbagisix.reward.domain;
-
-public class RewardVO {
-}

--- a/src/main/java/org/bbagisix/reward/dto/RewardDTO.java
+++ b/src/main/java/org/bbagisix/reward/dto/RewardDTO.java
@@ -1,4 +1,0 @@
-package org.bbagisix.reward.dto;
-
-public class RewardDTO {
-}

--- a/src/main/java/org/bbagisix/reward/mapper/RewardMapper.java
+++ b/src/main/java/org/bbagisix/reward/mapper/RewardMapper.java
@@ -1,4 +1,0 @@
-package org.bbagisix.reward.mapper;
-
-public interface RewardMapper {
-}

--- a/src/main/java/org/bbagisix/reward/service/RewardService.java
+++ b/src/main/java/org/bbagisix/reward/service/RewardService.java
@@ -1,4 +1,0 @@
-package org.bbagisix.reward.service;
-
-public class RewardService {
-}

--- a/src/main/java/org/bbagisix/tier/controller/TierController.java
+++ b/src/main/java/org/bbagisix/tier/controller/TierController.java
@@ -1,4 +1,43 @@
 package org.bbagisix.tier.controller;
 
+import java.util.List;
+
+import org.bbagisix.tier.dto.TierDTO;
+import org.bbagisix.tier.service.TierService;
+import org.bbagisix.user.dto.CustomOAuth2User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
 public class TierController {
+
+	private final TierService tierService;
+
+	/**
+	 * 개인 티어 조회
+	 * GET /api/user/me/tiers
+	 */
+	@GetMapping("/user/me/tiers")
+	public ResponseEntity<TierDTO> getUserCurrentTier(Authentication authentication) {
+		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
+		TierDTO currentTier = tierService.getUserCurrentTier(currentUser.getUserId());
+		return ResponseEntity.ok(currentTier);
+	}
+
+	/**
+	 * 전체 티어 조회
+	 * GET /api/tiers/all
+	 */
+	@GetMapping("/tiers/all")
+	public ResponseEntity<List<TierDTO>> getAllTiers() {
+		List<TierDTO> allTiers = tierService.getAllTiers();
+		return ResponseEntity.ok(allTiers);
+	}
 }

--- a/src/main/java/org/bbagisix/tier/controller/TierController.java
+++ b/src/main/java/org/bbagisix/tier/controller/TierController.java
@@ -1,0 +1,4 @@
+package org.bbagisix.tier.controller;
+
+public class TierController {
+}

--- a/src/main/java/org/bbagisix/tier/domain/TierVO.java
+++ b/src/main/java/org/bbagisix/tier/domain/TierVO.java
@@ -1,0 +1,15 @@
+package org.bbagisix.tier.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TierVO {
+	private Long tierId;
+	private String name;
+}

--- a/src/main/java/org/bbagisix/tier/dto/TierDTO.java
+++ b/src/main/java/org/bbagisix/tier/dto/TierDTO.java
@@ -1,0 +1,35 @@
+package org.bbagisix.tier.dto;
+
+import org.bbagisix.tier.domain.TierVO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TierDTO {
+	private Long tierId;
+	private String name;
+	private Boolean isCurrentTier; // 사용자의 현재 티어인지 여부
+
+	// TierVO를 TierDTO로 변환하는 정적 메서드
+	public static TierDTO from(TierVO tierVO) {
+		return TierDTO.builder()
+			.tierId(tierVO.getTierId())
+			.name(tierVO.getName())
+			.build();
+	}
+
+	// 사용자 정보를 포함한 TierDTO 생성
+	public static TierDTO fromWithUserInfo(TierVO tierVO, Long userCurrentTierId) {
+		return TierDTO.builder()
+			.tierId(tierVO.getTierId())
+			.name(tierVO.getName())
+			.isCurrentTier(tierVO.getTierId().equals(userCurrentTierId))
+			.build();
+	}
+}

--- a/src/main/java/org/bbagisix/tier/mapper/TierMapper.java
+++ b/src/main/java/org/bbagisix/tier/mapper/TierMapper.java
@@ -1,0 +1,4 @@
+package org.bbagisix.tier.mapper;
+
+public interface TierMapper {
+}

--- a/src/main/java/org/bbagisix/tier/mapper/TierMapper.java
+++ b/src/main/java/org/bbagisix/tier/mapper/TierMapper.java
@@ -1,4 +1,17 @@
 package org.bbagisix.tier.mapper;
 
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.bbagisix.tier.domain.TierVO;
+
+@Mapper
 public interface TierMapper {
+
+	// 모든 티어 목록 조회 (tier_order 순서대로)
+	List<TierVO> findAllTiers();
+
+	// 티어 ID로 단일 티어 조회
+	TierVO findById(@Param("tierId") Long tierId);
 }

--- a/src/main/java/org/bbagisix/tier/service/TierService.java
+++ b/src/main/java/org/bbagisix/tier/service/TierService.java
@@ -1,0 +1,4 @@
+package org.bbagisix.tier.service;
+
+public class TierService {
+}

--- a/src/main/java/org/bbagisix/tier/service/TierService.java
+++ b/src/main/java/org/bbagisix/tier/service/TierService.java
@@ -1,4 +1,75 @@
 package org.bbagisix.tier.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bbagisix.exception.BusinessException;
+import org.bbagisix.exception.ErrorCode;
+import org.bbagisix.tier.domain.TierVO;
+import org.bbagisix.tier.dto.TierDTO;
+import org.bbagisix.tier.mapper.TierMapper;
+import org.bbagisix.user.domain.UserVO;
+import org.bbagisix.user.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class TierService {
+
+	private final TierMapper tierMapper;
+	private final UserMapper userMapper;
+
+	// 모든 티어 목록 조회
+	public List<TierDTO> getAllTiers() {
+		List<TierVO> allTiers = tierMapper.findAllTiers();
+
+		return allTiers.stream()
+			.map(TierDTO::from)
+			.collect(Collectors.toList());
+	}
+
+	// 사용자의 현재 티어 조회
+	public TierDTO getUserCurrentTier(Long userId) {
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.USER_ID_REQUIRED);
+		}
+
+		// 사용자 정보 조회
+		UserVO user = userMapper.findByUserId(userId);
+		if (user == null) {
+			throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		// tier_id가 null이면 아직 티어가 없는 상태
+		if (user.getTierId() == null) {
+			return null;    // 또는 기본 티어 반환
+		}
+
+		// 현재 티어 조회
+		TierVO currentTier = tierMapper.findById(user.getTierId());
+		if (currentTier == null) {
+			log.warn("사용자 {}의 tier_id {}에 해당하는 티어를 찾을 수 없습니다.", userId, user.getTierId());
+			return null;
+		}
+
+		return TierDTO.from(currentTier);
+	}
+
+	// 챌린지 성공 시 티어 승급 처리
+	@Transactional
+	public void promoteUserTier(Long userId) {
+		UserVO user = userMapper.findByUserId(userId);
+		Long nextTierId = (user.getTierId() == null) ? 1L : user.getTierId() + 1;
+		TierVO nextTier = tierMapper.findById(nextTierId);
+
+		if (nextTier != null) {
+			userMapper.updateUserTier(userId, nextTierId);
+			log.info("사용자 {} 티어 승급: {} → {}", userId, user.getTierId(), nextTierId);
+		}
+	}
 }

--- a/src/main/java/org/bbagisix/user/domain/UserVO.java
+++ b/src/main/java/org/bbagisix/user/domain/UserVO.java
@@ -24,4 +24,5 @@ public class UserVO {
 	private boolean assetConnected;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
+	private Long tierId;
 }

--- a/src/main/java/org/bbagisix/user/mapper/UserMapper.java
+++ b/src/main/java/org/bbagisix/user/mapper/UserMapper.java
@@ -12,11 +12,17 @@ public interface UserMapper {
 
 	// 조회 메서드
 	UserVO findByUserId(@Param("userId") Long userId);
+
 	UserVO selectUserByEmail(@Param("email") String email);
+
 	UserVO selectUserById(@Param("userId") Long userId);
+
 	UserVO findByName(@Param("name") String name);
+
 	UserVO findBySocialId(@Param("socialId") String socialId);
+
 	UserVO findByEmail(@Param("email") String email);
+
 	String getNameByUserId(@Param("userId") Long userId);
 
 	// 이메일 중복 체크
@@ -27,4 +33,7 @@ public interface UserMapper {
 
 	// 계좌 연동 여부 업데이트
 	void updateAssetConnected(@Param("userId") Long userId, @Param("assetConnected") Boolean assetConnected);
+
+	// 사용자 티어 업데이트
+	int updateUserTier(@Param("userId") Long userId, @Param("tierId") Long tierId);
 }

--- a/src/main/resources/mappers/reward/RewardMapper.xml
+++ b/src/main/resources/mappers/reward/RewardMapper.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
-<mapper namespace="org.bbagisix.reward.mapper.RewardMapper">
-
-
-</mapper>

--- a/src/main/resources/mappers/tier/TierMapper.xml
+++ b/src/main/resources/mappers/tier/TierMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.bbagisix.tier.mapper.TierMapper">
+
+    <!-- 모든 티어 목록 조회 (tier_order 순서대로) -->
+    <select id="findAllTiers" resultType="org.bbagisix.tier.domain.TierVO">
+        SELECT tier_id,
+               name,
+               required_success_count,
+               tier_order
+        FROM tier
+        ORDER BY tier_order
+    </select>
+
+    <!-- 티어 ID로 단일 티어 조회 -->
+    <select id="findById" resultType="org.bbagisix.tier.domain.TierVO">
+        SELECT tier_id,
+               name,
+               required_success_count,
+               tier_order
+        FROM tier
+        WHERE tier_id = #{tierId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -5,48 +5,75 @@
 
 <mapper namespace="org.bbagisix.user.mapper.UserMapper">
 
-    <insert id="insertUser" parameterType="org.bbagisix.user.domain.UserVO" useGeneratedKeys="true" keyProperty="userId">
+    <insert id="insertUser" parameterType="org.bbagisix.user.domain.UserVO" useGeneratedKeys="true"
+            keyProperty="userId">
         insert into user (name, nickname, password, email, age, email_verified, role, social_id)
         values (#{name}, #{nickname}, #{password}, #{email}, #{age}, #{emailVerified}, #{role}, #{socialId})
     </insert>
 
     <select id="selectUserByEmail" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where email = #{email}
+        select *
+        from user
+        where email = #{email}
     </select>
 
     <select id="selectUserById" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where user_id = #{userId}
+        select *
+        from user
+        where user_id = #{userId}
     </select>
 
     <select id="countByEmail" resultType="int">
-        select count(*) from user where email = #{email}
+        select count(*)
+        from user
+        where email = #{email}
     </select>
 
     <select id="findByName" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where name = #{name}
+        select *
+        from user
+        where name = #{name}
     </select>
 
     <select id="findBySocialId" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where social_id = #{socialId}
+        select *
+        from user
+        where social_id = #{socialId}
     </select>
 
     <select id="findByEmail" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where email = #{email}
+        select *
+        from user
+        where email = #{email}
     </select>
 
     <select id="findByUserId" resultType="org.bbagisix.user.domain.UserVO">
-        select * from user where user_id = #{userId}
+        select *
+        from user
+        where user_id = #{userId}
     </select>
 
     <select id="getNameByUserId" resultType="java.lang.String">
-        select name from user where user_id = #{userId}
+        select name
+        from user
+        where user_id = #{userId}
     </select>
 
     <update id="updateNickname">
-        update user set nickname = #{nickname} where user_id = #{userId}
+        update user
+        set nickname = #{nickname}
+        where user_id = #{userId}
     </update>
 
     <update id="updateAssetConnected">
-        update user set asset_connected = #{assetConnected} where user_id = #{userId}
+        update user
+        set asset_connected = #{assetConnected}
+        where user_id = #{userId}
+    </update>
+
+    <update id="updateUserTier">
+        update user
+        set tier_id = #{tierId}
+        where user_id = #{userId}
     </update>
 </mapper>

--- a/src/test/java/org/bbagisix/tier/controller/TierControllerTest.java
+++ b/src/test/java/org/bbagisix/tier/controller/TierControllerTest.java
@@ -1,0 +1,192 @@
+package org.bbagisix.tier.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bbagisix.tier.dto.TierDTO;
+import org.bbagisix.tier.service.TierService;
+import org.bbagisix.user.dto.CustomOAuth2User;
+import org.bbagisix.user.dto.UserResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class TierControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Mock
+	private TierService tierService;
+
+	@InjectMocks
+	private TierController tierController;
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+	private TierDTO bronzeTier;
+	private TierDTO silverTier;
+	private TierDTO goldTier;
+	private CustomOAuth2User mockUser;
+	private Authentication mockAuthentication;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(tierController).build();
+
+		// 테스트 데이터 준비
+		bronzeTier = TierDTO.builder()
+			.tierId(1L)
+			.name("브론즈")
+			.build();
+
+		silverTier = TierDTO.builder()
+			.tierId(2L)
+			.name("실버")
+			.build();
+
+		goldTier = TierDTO.builder()
+			.tierId(3L)
+			.name("골드")
+			.build();
+
+		// Mock 사용자 생성
+		UserResponse userResponse = UserResponse.builder()
+			.userId(1L)
+			.name("테스트유저")
+			.email("test@test.com")
+			.nickname("테스트닉네임")
+			.role("ROLE_USER")
+			.build();
+
+		mockUser = new CustomOAuth2User(userResponse);
+		mockAuthentication = new UsernamePasswordAuthenticationToken(
+			mockUser, null, mockUser.getAuthorities());
+	}
+
+	@Test
+	@DisplayName("사용자 현재 티어 조회 테스트 - 성공")
+	void getUserCurrentTier_Success() throws Exception {
+		// given
+		when(tierService.getUserCurrentTier(1L)).thenReturn(silverTier);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/user/me/tiers")
+				.principal(mockAuthentication)
+				.characterEncoding("UTF-8"))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then - JSON 응답을 UTF-8로 읽기
+		String jsonResponse = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		TierDTO responseDto = objectMapper.readValue(jsonResponse, TierDTO.class);
+
+		assertEquals(2L, responseDto.getTierId());
+		assertEquals("실버", responseDto.getName());
+
+		verify(tierService, times(1)).getUserCurrentTier(1L);
+	}
+
+	@Test
+	@DisplayName("사용자 현재 티어 조회 테스트 - 티어 없음")
+	void getUserCurrentTier_NoTier() throws Exception {
+		// given
+		when(tierService.getUserCurrentTier(1L)).thenReturn(null);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/user/me/tiers")
+				.principal(mockAuthentication)
+				.characterEncoding("UTF-8"))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		assertTrue(content.isEmpty() || content.equals("null"));
+
+		verify(tierService, times(1)).getUserCurrentTier(1L);
+	}
+
+	@Test
+	@DisplayName("전체 티어 목록 조회 테스트 - 성공")
+	void getAllTiers_Success() throws Exception {
+		// given
+		List<TierDTO> allTiers = Arrays.asList(bronzeTier, silverTier, goldTier);
+		when(tierService.getAllTiers()).thenReturn(allTiers);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/tiers/all")
+				.principal(mockAuthentication)
+				.characterEncoding("UTF-8"))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then - JSON 배열을 UTF-8로 읽기
+		String jsonResponse = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		TierDTO[] responseArray = objectMapper.readValue(jsonResponse, TierDTO[].class);
+
+		assertEquals(3, responseArray.length);
+		assertEquals(1L, responseArray[0].getTierId());
+		assertEquals("브론즈", responseArray[0].getName());
+		assertEquals(2L, responseArray[1].getTierId());
+		assertEquals("실버", responseArray[1].getName());
+		assertEquals(3L, responseArray[2].getTierId());
+		assertEquals("골드", responseArray[2].getName());
+
+		verify(tierService, times(1)).getAllTiers();
+	}
+
+	@Test
+	@DisplayName("컨트롤러 직접 호출 테스트 - getUserCurrentTier")
+	void directCall_getUserCurrentTier() {
+		// given
+		when(tierService.getUserCurrentTier(1L)).thenReturn(silverTier);
+
+		// when
+		ResponseEntity<TierDTO> response = tierController.getUserCurrentTier(mockAuthentication);
+
+		// then
+		assertEquals(200, response.getStatusCodeValue());
+		assertEquals(2L, response.getBody().getTierId());
+		assertEquals("실버", response.getBody().getName());
+
+		verify(tierService, times(1)).getUserCurrentTier(1L);
+	}
+
+	@Test
+	@DisplayName("컨트롤러 직접 호출 테스트 - getAllTiers")
+	void directCall_getAllTiers() {
+		// given
+		List<TierDTO> allTiers = Arrays.asList(bronzeTier, silverTier, goldTier);
+		when(tierService.getAllTiers()).thenReturn(allTiers);
+
+		// when
+		ResponseEntity<List<TierDTO>> response = tierController.getAllTiers();
+
+		// then
+		assertEquals(200, response.getStatusCodeValue());
+		assertEquals(3, response.getBody().size());
+		assertEquals("브론즈", response.getBody().get(0).getName());
+		assertEquals("실버", response.getBody().get(1).getName());
+		assertEquals("골드", response.getBody().get(2).getName());
+
+		verify(tierService, times(1)).getAllTiers();
+	}
+}

--- a/src/test/java/org/bbagisix/tier/service/TierServiceTest.java
+++ b/src/test/java/org/bbagisix/tier/service/TierServiceTest.java
@@ -1,0 +1,181 @@
+package org.bbagisix.tier.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bbagisix.tier.domain.TierVO;
+import org.bbagisix.tier.dto.TierDTO;
+import org.bbagisix.tier.mapper.TierMapper;
+import org.bbagisix.user.domain.UserVO;
+import org.bbagisix.user.mapper.UserMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TierServiceTest {
+
+	@Mock
+	private TierMapper tierMapper;
+
+	@Mock
+	private UserMapper userMapper;
+
+	@InjectMocks
+	private TierService tierService;
+
+	private TierVO bronzeTier;
+	private TierVO silverTier;
+	private TierVO goldTier;
+	private UserVO testUser;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 데이터 준비
+		bronzeTier = TierVO.builder()
+			.tierId(1L)
+			.name("브론즈")
+			.build();
+
+		silverTier = TierVO.builder()
+			.tierId(2L)
+			.name("실버")
+			.build();
+
+		goldTier = TierVO.builder()
+			.tierId(3L)
+			.name("골드")
+			.build();
+
+		testUser = UserVO.builder()
+			.userId(1L)
+			.name("테스트유저")
+			.email("test@test.com")
+			.tierId(1L) // 브론즈 티어
+			.build();
+	}
+
+	@Test
+	@DisplayName("전체 티어 목록 조회 테스트")
+	void getAllTiers() {
+		// given
+		List<TierVO> mockTiers = Arrays.asList(bronzeTier, silverTier, goldTier);
+		when(tierMapper.findAllTiers()).thenReturn(mockTiers);
+
+		// when
+		List<TierDTO> result = tierService.getAllTiers();
+
+		// then
+		assertEquals(3, result.size());
+		assertEquals("브론즈", result.get(0).getName());
+		assertEquals("실버", result.get(1).getName());
+		assertEquals("골드", result.get(2).getName());
+
+		verify(tierMapper, times(1)).findAllTiers();
+	}
+
+	@Test
+	@DisplayName("사용자 현재 티어 조회 테스트 - 정상")
+	void getUserCurrentTier_Success() {
+		// given
+		when(userMapper.findByUserId(1L)).thenReturn(testUser);
+		when(tierMapper.findById(1L)).thenReturn(bronzeTier);
+
+		// when
+		TierDTO result = tierService.getUserCurrentTier(1L);
+
+		// then
+		assertNotNull(result);
+		assertEquals(1L, result.getTierId());
+		assertEquals("브론즈", result.getName());
+
+		verify(userMapper, times(1)).findByUserId(1L);
+		verify(tierMapper, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("사용자 현재 티어 조회 테스트 - tier_id가 null")
+	void getUserCurrentTier_TierIdNull() {
+		// given
+		UserVO userWithoutTier = UserVO.builder()
+			.userId(1L)
+			.name("신규유저")
+			.tierId(null) // 티어 없음
+			.build();
+
+		when(userMapper.findByUserId(1L)).thenReturn(userWithoutTier);
+
+		// when
+		TierDTO result = tierService.getUserCurrentTier(1L);
+
+		// then
+		assertNull(result);
+		verify(userMapper, times(1)).findByUserId(1L);
+		verify(tierMapper, never()).findById(any());
+	}
+
+	@Test
+	@DisplayName("티어 승급 테스트 - 첫 승급 (null → 1)")
+	void promoteUserTier_FirstPromotion() {
+		// given
+		UserVO newUser = UserVO.builder()
+			.userId(1L)
+			.tierId(null) // 아직 티어 없음
+			.build();
+
+		when(userMapper.findByUserId(1L)).thenReturn(newUser);
+		when(tierMapper.findById(1L)).thenReturn(bronzeTier);
+
+		// when
+		tierService.promoteUserTier(1L);
+
+		// then
+		verify(userMapper, times(1)).findByUserId(1L);
+		verify(tierMapper, times(1)).findById(1L);
+		verify(userMapper, times(1)).updateUserTier(1L, 1L);
+	}
+
+	@Test
+	@DisplayName("티어 승급 테스트 - 일반 승급 (1 → 2)")
+	void promoteUserTier_NormalPromotion() {
+		// given
+		when(userMapper.findByUserId(1L)).thenReturn(testUser);
+		when(tierMapper.findById(2L)).thenReturn(silverTier);
+
+		// when
+		tierService.promoteUserTier(1L);
+
+		// then
+		verify(userMapper, times(1)).findByUserId(1L);
+		verify(tierMapper, times(1)).findById(2L);
+		verify(userMapper, times(1)).updateUserTier(1L, 2L);
+	}
+
+	@Test
+	@DisplayName("티어 승급 테스트 - 최고 티어 (승급 안됨)")
+	void promoteUserTier_MaxTier() {
+		// given
+		UserVO maxTierUser = UserVO.builder()
+			.userId(1L)
+			.tierId(3L) // 골드 티어 (최고)
+			.build();
+
+		when(userMapper.findByUserId(1L)).thenReturn(maxTierUser);
+		when(tierMapper.findById(4L)).thenReturn(null); // 다음 티어 없음
+
+		// when
+		tierService.promoteUserTier(1L);
+
+		// then
+		verify(userMapper, times(1)).findByUserId(1L);
+		verify(tierMapper, times(1)).findById(4L);
+		verify(userMapper, never()).updateUserTier(any(), any()); // 승급 안됨
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #162 

## ✨ 내용
### 1. Tier 관련 API
- **회원 티어 조회**: `GET /api/user/me/tiers`
- **전체 티어 조회**: `GET /api/tiers/all`
### 2. 도메인
- **`TierVO`**  
  - DB `tier` 테이블과 매핑  
  - 필드: `tierId`, `name`
- **`TierDTO`**  
  - API 응답용  
  - 필드: `tierId`, `name`, `isCurrentTier`
### 3. Mapper
#### 3.1. TierMapper
- `findAllTiers()` : 모든 티어 목록 조회 (`tier_order` 순서대로)
- `findById(userId)` : 사용자 현재 티어 조회
#### 3.2. UserMapper
- `updateUserTier(userId, tierId)` : 사용자 현재 티어 승급
### 4. TierService
- `getAllTiers()`  
  - 전체 티어 목록 조회  
  - VO → DTO 변환
- `getUserCurrentTier(userId)`  
  - 사용자 현재 티어 조회  
  - `tier_id`가 `NULL`이면 `null` 반환
- `promoteUserTier(userId)`  
  - 핵심 승급 로직

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
