### PR TITLE
[BUG] api/expeses 엔드포인트에서 N + 1 쿼리 문제 수정

### DIFF
--- a/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
+++ b/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
@@ -14,6 +14,8 @@ public interface AssetMapper {
 
 	AssetVO selectAssetByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status);
 
+	AssetVO selectAssetById(@Param("assetId") Long assetId);
+
 	int deleteUserAssetByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status);
 
 	int deleteExpensesByUserId(Long userId);

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.bbagisix.expense.domain.ExpenseVO;
+import org.bbagisix.expense.dto.ExpenseDTO;
 
 @Mapper
 public interface ExpenseMapper {
@@ -14,6 +15,8 @@ public interface ExpenseMapper {
 	ExpenseVO findById(Long expenditureId);
 
 	List<ExpenseVO> findAllByUserId(Long userId);
+
+	List<ExpenseDTO> findAllByUserIdWithDetails(Long userId);
 
 	int update(ExpenseVO expense);
 

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -213,15 +213,11 @@ public class ExpenseServiceImpl implements ExpenseService {
 			CategoryVO categoryVO = categoryMapper.findById(vo.getCategoryId());
 			if (categoryVO != null) {
 				dto.setCategoryName(categoryVO.getName());
-				dto.setCategoryIcon(categoryVO.getIcon());
 			}
 		}
 
 		if (vo.getAssetId() != null) {
-			AssetVO assetVO = assetMapper.selectAssetByUserIdAndStatus(vo.getUserId(), "main");
-			if (assetVO == null) {
-				assetVO = assetMapper.selectAssetByUserIdAndStatus(vo.getUserId(), "sub");
-			}
+			AssetVO assetVO = assetMapper.selectAssetById(vo.getAssetId());
 			if (assetVO != null) {
 				dto.setAssetName(assetVO.getAssetName());
 				dto.setBankName(assetVO.getBankName());

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -64,7 +64,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 	@Override
 	public List<ExpenseDTO> getExpensesByUserId(Long userId) {
 		try {
-			return expenseMapper.findAllByUserId(userId).stream().map(this::voToDto).collect(Collectors.toList());
+			return expenseMapper.findAllByUserIdWithDetails(userId);
 		} catch (Exception e) {
 			log.error("사용자 소비내역 목록 조회 중 오류 발생: userId={}, error={}", userId, e.getMessage(), e);
 			throw new BusinessException(ErrorCode.DATA_ACCESS_ERROR, e);

--- a/src/main/resources/mappers/asset/AssetMapper.xml
+++ b/src/main/resources/mappers/asset/AssetMapper.xml
@@ -74,6 +74,23 @@
           AND status = #{status}
     </select>
 
+    <select id="selectAssetById" resultMap="AssetResultMap">
+        select
+            asset_id,
+            user_id,
+            asset_name,
+            bank_name,
+            bank_account,
+            bank_id,
+            bank_pw,
+            connected_id,
+            balance,
+            created_at,
+            status
+        from user_asset
+        where asset_id = #{assetId}
+    </select>
+
     <delete id="deleteUserAssetByUserIdAndStatus">
         delete from user_asset
         where user_id = #{userId}

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -39,6 +39,27 @@
         ORDER BY expenditure_date DESC
     </select>
 
+    <select id="findAllByUserIdWithDetails" parameterType="long" resultType="org.bbagisix.expense.dto.ExpenseDTO">
+        SELECT e.expenditure_id as expenditureId,
+               e.user_id as userId,
+               e.category_id as categoryId,
+               e.asset_id as assetId,
+               e.amount,
+               e.description,
+               e.expenditure_date as expenditureDate,
+               e.created_at as createdAt,
+               e.updated_at as updatedAt,
+               c.name as categoryName,
+               c.icon as categoryIcon,
+               a.asset_name as assetName,
+               a.bank_name as bankName
+        FROM expenditure e
+        LEFT JOIN category c ON e.category_id = c.category_id
+        LEFT JOIN user_asset a ON e.asset_id = a.asset_id
+        WHERE e.user_id = #{userId}
+        ORDER BY e.expenditure_date DESC
+    </select>
+
     <update id="update" parameterType="org.bbagisix.expense.domain.ExpenseVO">
         UPDATE expenditure
         SET category_id      = #{categoryId},

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -50,7 +50,6 @@
                e.created_at as createdAt,
                e.updated_at as updatedAt,
                c.name as categoryName,
-               c.icon as categoryIcon,
                a.asset_name as assetName,
                a.bank_name as bankName
         FROM expenditure e


### PR DESCRIPTION
## 📌 관련 이슈
closed #167 

## ✨ 내용
🔍 문제: ExpensesServiceImpl의 voToDto() 메서드

각 expense 마다 categoryMapper.findById() 개별 호출
각 expense 마다 assetMapper.selectAssetByUserIdAndStatus() 개별 호출
TooManyResultsException 해결
expenses 개수가 100개면 최대 201번의 쿼리 실행

🛠️ 해결 방안

JOIN 쿼리를 사용한 일괄 조회로 변경

ExpenseMapper.xml에 새로운 쿼리 추가
ExpenseServiceImpl의 getExpensesByUserId() 메서드 수정
N+1 -> 1 쿼리로 성능 개선

