### PR TITLE
[BUG] 지출 내역 생성/수정 기능 오류 수정

### DIFF
--- a/src/main/java/org/bbagisix/expense/controller/ExpenseController.java
+++ b/src/main/java/org/bbagisix/expense/controller/ExpenseController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.core.Authentication;
 import org.bbagisix.user.dto.CustomOAuth2User;

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -1,5 +1,6 @@
 package org.bbagisix.expense.service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,6 +29,13 @@ public class ExpenseServiceImpl implements ExpenseService {
 	@Override
 	public ExpenseDTO createExpense(ExpenseDTO expenseDTO) {
 		try {
+			// 항상 사용자의 main 계좌로 설정
+			AssetVO mainAsset = assetMapper.selectAssetByUserIdAndStatus(expenseDTO.getUserId(), "main");
+			if (mainAsset == null) {
+				throw new BusinessException(ErrorCode.ASSET_NOT_FOUND, "main 계좌가 연결되지 않았습니다.");
+			}
+			expenseDTO.setAssetId(mainAsset.getAssetId());
+			
 			ExpenseVO vo = dtoToVo(expenseDTO);
 			expenseMapper.insert(vo);
 			if (vo.getExpenditureId() == null) {
@@ -82,8 +90,14 @@ public class ExpenseServiceImpl implements ExpenseService {
 				throw new BusinessException(ErrorCode.EXPENSE_ACCESS_DENIED);
 			}
 
+			// 항상 사용자의 main 계좌로 설정
+			AssetVO mainAsset = assetMapper.selectAssetByUserIdAndStatus(userId, "main");
+			if (mainAsset == null) {
+				throw new BusinessException(ErrorCode.ASSET_NOT_FOUND, "main 계좌가 연결되지 않았습니다.");
+			}
+
 			vo.setCategoryId(expenseDTO.getCategoryId());
-			vo.setAssetId(expenseDTO.getAssetId());
+			vo.setAssetId(mainAsset.getAssetId());
 			vo.setAmount(expenseDTO.getAmount());
 			vo.setDescription(expenseDTO.getDescription());
 			vo.setExpenditureDate(expenseDTO.getExpenditureDate());


### PR DESCRIPTION
## 📌 관련 이슈
closed #181 

## ✨ 내용
내역 생성, 수정이 되지 않아. assetMapper의 selectAssetByUserIdAndStatus에 main으로 설정.
원래는 저금통까지 두 개의 계좌에 모두 생성, 수정이 되는 오류가 있었음.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
