### PR TITLE
[FEAT] 이전 챌린지 목록(성공실패) api 구현

### DIFF
--- a/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
@@ -35,4 +35,8 @@ public interface ChallengeMapper {
 
 	UserChallengeVO getUserChallengeById(Long userChallengeId);
 
+	// 완료된 챌린지들만 조회 (completed + failed)
+	List<UserChallengeVO> getUserCompletedChallenges(@Param("userId") Long userId);
+
+
 }

--- a/src/main/java/org/bbagisix/mypage/controller/MyPageController.java
+++ b/src/main/java/org/bbagisix/mypage/controller/MyPageController.java
@@ -1,6 +1,9 @@
 package org.bbagisix.mypage.controller;
 
+import java.util.List;
+
 import org.bbagisix.mypage.domain.MyPageAccountDTO;
+import org.bbagisix.mypage.domain.UserChallengeDTO;
 import org.bbagisix.mypage.service.MyPageService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -25,6 +28,10 @@ public class MyPageController {
 		return ResponseEntity.ok(response);
 	}
 
+	@GetMapping("/challenges/completed")
+	public ResponseEntity<List<UserChallengeDTO>> getUserChallenges(Authentication authentication) {
+		List<UserChallengeDTO> challenges = myPageService.getUserChallenges(authentication);
+		return ResponseEntity.ok(challenges);
+	}
 	// @GetMapping("/tier")          // 뱃지 목록
-	// @GetMapping("/challenges")      // 챌린지 요약
 }

--- a/src/main/java/org/bbagisix/mypage/domain/UserChallengeDTO.java
+++ b/src/main/java/org/bbagisix/mypage/domain/UserChallengeDTO.java
@@ -13,15 +13,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserChallengeDTO {
 	private Long userChallengeId;
-	private String title;           // 챌린지 제목
-	private String status;          // completed, failed
+	private String title;
+	private String status;
 
 	// JSON 출력 시 날짜 형식 지정
 	@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-	private Date startDate;         // 시작일
+	private Date startDate;
 
 	@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-	private Date endDate;           // 종료일
+	private Date endDate;
 
-	private Long categoryId;        // 아이콘용
+	private Long categoryId;
 }

--- a/src/main/java/org/bbagisix/mypage/domain/UserChallengeDTO.java
+++ b/src/main/java/org/bbagisix/mypage/domain/UserChallengeDTO.java
@@ -1,0 +1,27 @@
+package org.bbagisix.mypage.domain;
+
+import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserChallengeDTO {
+	private Long userChallengeId;
+	private String title;           // 챌린지 제목
+	private String status;          // completed, failed
+
+	// JSON 출력 시 날짜 형식 지정
+	@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Date startDate;         // 시작일
+
+	@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Date endDate;           // 종료일
+
+	private Long categoryId;        // 아이콘용
+}

--- a/src/main/java/org/bbagisix/mypage/service/MyPageService.java
+++ b/src/main/java/org/bbagisix/mypage/service/MyPageService.java
@@ -1,10 +1,17 @@
 package org.bbagisix.mypage.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.bbagisix.asset.domain.AssetVO;
 import org.bbagisix.asset.mapper.AssetMapper;
+import org.bbagisix.challenge.domain.ChallengeVO;
+import org.bbagisix.challenge.domain.UserChallengeVO;
+import org.bbagisix.challenge.mapper.ChallengeMapper;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
 import org.bbagisix.mypage.domain.MyPageAccountDTO;
+import org.bbagisix.mypage.domain.UserChallengeDTO;
 import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -18,6 +25,7 @@ import lombok.extern.log4j.Log4j2;
 public class MyPageService {
 
 	private final AssetMapper assetMapper;
+	private final ChallengeMapper challengeMapper;
 
 	public MyPageAccountDTO getUserAccountData(Authentication authentication) {
 		Long userId = extractUserId(authentication);
@@ -32,6 +40,22 @@ public class MyPageService {
 			.mainAccount(mainAsset != null ? convertToAccountInfo(mainAsset) : null)
 			.subAccount(subAsset != null ? convertToAccountInfo(subAsset) : null)
 			.build();
+	}
+
+	/**
+	 * 마이페이지 - 완료된(complete/failed) 사용자 챌린지 목록 조회
+	 * - challengeMapper.getUserCompletedChallenges(userId)
+	 *   결과(UserChallengeVO)를 UserChallengeDTO로 변환하여 반환
+	 */
+	public List<UserChallengeDTO> getUserChallenges(Authentication authentication) {
+		Long userId = extractUserId(authentication);
+
+		// 완료된 챌린지들 조회 (completed + failed)
+		List<UserChallengeVO> userChallenges = challengeMapper.getUserCompletedChallenges(userId);
+
+		return userChallenges.stream()
+			.map(this::convertToUserChallengeDTO)
+			.collect(Collectors.toList());
 	}
 
 	// Authentication에서 사용자 ID 추출
@@ -55,6 +79,21 @@ public class MyPageService {
 			.bankName(assetVO.getBankName())
 			.balance(assetVO.getBalance())
 			.status(assetVO.getStatus())
+			.build();
+	}
+
+	private UserChallengeDTO convertToUserChallengeDTO(UserChallengeVO userChallenge) {
+		// 챌린지 상세 정보 조회
+		ChallengeVO challenge = challengeMapper.findByChallengeId(userChallenge.getChallengeId());
+		Long categoryId = challengeMapper.getCategoryByChallengeId(userChallenge.getChallengeId());
+
+		return UserChallengeDTO.builder()
+			.userChallengeId(userChallenge.getUserChallengeId())
+			.title(challenge != null ? challenge.getTitle() : "알 수 없는 챌린지")
+			.status(userChallenge.getStatus())
+			.startDate(userChallenge.getStartDate())
+			.endDate(userChallenge.getEndDate())
+			.categoryId(categoryId)
 			.build();
 	}
 }

--- a/src/main/java/org/bbagisix/mypage/service/MyPageService.java
+++ b/src/main/java/org/bbagisix/mypage/service/MyPageService.java
@@ -42,15 +42,10 @@ public class MyPageService {
 			.build();
 	}
 
-	/**
-	 * 마이페이지 - 완료된(complete/failed) 사용자 챌린지 목록 조회
-	 * - challengeMapper.getUserCompletedChallenges(userId)
-	 *   결과(UserChallengeVO)를 UserChallengeDTO로 변환하여 반환
-	 */
+	// 완료된(complete/failed) 사용자 챌린지 목록 조회
 	public List<UserChallengeDTO> getUserChallenges(Authentication authentication) {
 		Long userId = extractUserId(authentication);
 
-		// 완료된 챌린지들 조회 (completed + failed)
 		List<UserChallengeVO> userChallenges = challengeMapper.getUserCompletedChallenges(userId);
 
 		return userChallenges.stream()

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -127,7 +127,7 @@
         where user_challenge_id = #{userChallengeId}
     </select>
 
-    <!-- ✅ (신규) 완료된 챌린지들 조회 (completed + failed) -->
+    <!--  완료된 챌린지들 조회 (completed + failed) -->
     <select id="getUserCompletedChallenges" resultType="org.bbagisix.challenge.domain.UserChallengeVO">
         SELECT
             user_challenge_id,

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -127,4 +127,22 @@
         where user_challenge_id = #{userChallengeId}
     </select>
 
+    <!-- ✅ (신규) 완료된 챌린지들 조회 (completed + failed) -->
+    <select id="getUserCompletedChallenges" resultType="org.bbagisix.challenge.domain.UserChallengeVO">
+        SELECT
+            user_challenge_id,
+            user_id,
+            challenge_id,
+            status,
+            period,
+            progress,
+            start_date,
+            end_date,
+            saving,
+            is_active
+        FROM user_challenge
+        WHERE user_id = #{userId}
+          AND status IN ('completed', 'failed')
+        ORDER BY end_date DESC, start_date DESC
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈

  closed #190

## ✨ 내용

API 엔드포인트: GET /api/mypage/challenges/completed
기능: 로그인한 사용자의 완료된 챌린지(성공/실패) 목록 반환
응답 데이터: 챌린지 제목, 상태, 시작일, 종료일, 카테고리 정보


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

