### PR TITLE
[FEAT] 마이페이지 티어 API

### DIFF
--- a/src/main/java/org/bbagisix/challenge/service/ChallengeService.java
+++ b/src/main/java/org/bbagisix/challenge/service/ChallengeService.java
@@ -16,6 +16,7 @@ import org.bbagisix.challenge.mapper.ChallengeMapper;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
 import org.bbagisix.expense.mapper.ExpenseMapper;
+import org.bbagisix.tier.service.TierService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ public class ChallengeService {
 	private final ChallengeMapper challengeMapper;
 	private final ExpenseMapper expenseMapper;
 	private final AnalyticsService analyticsService;
+	private final TierService tierService;
 
 	public ChallengeDTO getChallengeById(Long challengeId) {
 		if (challengeId == null) {
@@ -139,6 +141,11 @@ public class ChallengeService {
 					.progress(c.getProgress() + 1)
 					.status(isLastDay ? "completed" : c.getStatus()) // 마지막 날인 경우 -> 최종 성공
 					.build();
+				
+				// 챌린지 완료 시 tier 승급 처리
+				if (isLastDay) {
+					tierService.promoteUserTier(userId);
+				}
 			}
 
 			challengeMapper.updateChallenge(updated);

--- a/src/main/java/org/bbagisix/mypage/controller/MyPageController.java
+++ b/src/main/java/org/bbagisix/mypage/controller/MyPageController.java
@@ -1,6 +1,6 @@
 package org.bbagisix.mypage.controller;
 
-import org.bbagisix.mypage.domain.MyPageAccountDTO;
+import org.bbagisix.mypage.domain.MyPageDTO;
 import org.bbagisix.mypage.service.MyPageService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -20,11 +20,16 @@ public class MyPageController {
 	private final MyPageService myPageService;
 
 	@GetMapping("/accounts")
-	public ResponseEntity<MyPageAccountDTO> getUserAccounts(Authentication authentication) {
-		MyPageAccountDTO response = myPageService.getUserAccountData(authentication);
+	public ResponseEntity<MyPageDTO> getUserAccounts(Authentication authentication) {
+		MyPageDTO response = myPageService.getUserAccountData(authentication);
 		return ResponseEntity.ok(response);
 	}
 
-	// @GetMapping("/tier")          // 뱃지 목록
+	@GetMapping("/tier")
+	public ResponseEntity<MyPageDTO.TierInfo> getUserTier(Authentication authentication) {
+		MyPageDTO.TierInfo tierInfo = myPageService.getUserTierInfo(authentication);
+		return ResponseEntity.ok(tierInfo);
+	}
+
 	// @GetMapping("/challenges")      // 챌린지 요약
 }

--- a/src/main/java/org/bbagisix/mypage/domain/MyPageAccountDTO.java
+++ b/src/main/java/org/bbagisix/mypage/domain/MyPageAccountDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class MyPageAccountDTO {
 	private AccountInfo mainAccount;
 	private AccountInfo subAccount;
+	private TierInfo tierInfo;
 
 	@Getter
 	@Builder
@@ -23,5 +24,15 @@ public class MyPageAccountDTO {
 		private String bankName;
 		private Long balance;
 		private String status;    // main, sub
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class TierInfo {
+		private Long tierId;
+		private String tierName;
+		private Integer completedChallenges;
 	}
 }

--- a/src/main/java/org/bbagisix/mypage/domain/MyPageDTO.java
+++ b/src/main/java/org/bbagisix/mypage/domain/MyPageDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MyPageAccountDTO {
+public class MyPageDTO {
 	private AccountInfo mainAccount;
 	private AccountInfo subAccount;
 	private TierInfo tierInfo;

--- a/src/main/java/org/bbagisix/mypage/service/MyPageService.java
+++ b/src/main/java/org/bbagisix/mypage/service/MyPageService.java
@@ -4,8 +4,11 @@ import org.bbagisix.asset.domain.AssetVO;
 import org.bbagisix.asset.mapper.AssetMapper;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
-import org.bbagisix.mypage.domain.MyPageAccountDTO;
+import org.bbagisix.mypage.domain.MyPageDTO;
+import org.bbagisix.tier.service.TierService;
+import org.bbagisix.tier.dto.TierDTO;
 import org.bbagisix.user.dto.CustomOAuth2User;
+import org.bbagisix.user.mapper.UserMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -18,8 +21,10 @@ import lombok.extern.log4j.Log4j2;
 public class MyPageService {
 
 	private final AssetMapper assetMapper;
+	private final UserMapper userMapper;
+	private final TierService tierService;
 
-	public MyPageAccountDTO getUserAccountData(Authentication authentication) {
+	public MyPageDTO getUserAccountData(Authentication authentication) {
 		Long userId = extractUserId(authentication);
 
 		// main 계좌 조회
@@ -28,9 +33,38 @@ public class MyPageService {
 		// sub 계좌 조회
 		AssetVO subAsset = assetMapper.selectAssetByUserIdAndStatus(userId, "sub");
 
-		return MyPageAccountDTO.builder()
+		// tier 정보 조회
+		MyPageDTO.TierInfo tierInfo = getUserTierInfo(authentication);
+
+		return MyPageDTO.builder()
 			.mainAccount(mainAsset != null ? convertToAccountInfo(mainAsset) : null)
 			.subAccount(subAsset != null ? convertToAccountInfo(subAsset) : null)
+			.tierInfo(tierInfo)
+			.build();
+	}
+
+	public MyPageDTO.TierInfo getUserTierInfo(Authentication authentication) {
+		Long userId = extractUserId(authentication);
+
+		// 현재 티어 정보 조회
+		TierDTO currentTier = tierService.getUserCurrentTier(userId);
+
+		// 완료한 챌린지 수 조회
+		Integer completedChallenges = getCompletedChallengeCount(userId);
+
+		if (currentTier == null) {
+			// 티어가 없는 경우 기본값 반환
+			return MyPageDTO.TierInfo.builder()
+				.tierId(null)
+				.tierName("티어 없음")
+				.completedChallenges(completedChallenges)
+				.build();
+		}
+
+		return MyPageDTO.TierInfo.builder()
+			.tierId(currentTier.getTierId())
+			.tierName(currentTier.getName())
+			.completedChallenges(completedChallenges)
 			.build();
 	}
 
@@ -48,13 +82,18 @@ public class MyPageService {
 		return curUser.getUserId();
 	}
 
-	private MyPageAccountDTO.AccountInfo convertToAccountInfo(AssetVO assetVO) {
-		return MyPageAccountDTO.AccountInfo.builder()
+	private MyPageDTO.AccountInfo convertToAccountInfo(AssetVO assetVO) {
+		return MyPageDTO.AccountInfo.builder()
 			.assetId(assetVO.getAssetId())
 			.assetName(assetVO.getAssetName())
 			.bankName(assetVO.getBankName())
 			.balance(assetVO.getBalance())
 			.status(assetVO.getStatus())
 			.build();
+	}
+
+	private Integer getCompletedChallengeCount(Long userId) {
+		Integer count = userMapper.getCompletedChallengeCount(userId);
+		return count != null ? count : 0;
 	}
 }

--- a/src/main/java/org/bbagisix/tier/controller/TierController.java
+++ b/src/main/java/org/bbagisix/tier/controller/TierController.java
@@ -8,6 +8,7 @@ import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,5 +40,16 @@ public class TierController {
 	public ResponseEntity<List<TierDTO>> getAllTiers() {
 		List<TierDTO> allTiers = tierService.getAllTiers();
 		return ResponseEntity.ok(allTiers);
+	}
+	
+	/**
+	 * 사용자 tier 재계산 (테스트/디버깅용)
+	 * POST /api/user/me/tiers/recalculate
+	 */
+	@PostMapping("/user/me/tiers/recalculate")
+	public ResponseEntity<String> recalculateUserTier(Authentication authentication) {
+		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
+		tierService.recalculateUserTier(currentUser.getUserId());
+		return ResponseEntity.ok("Tier 재계산이 완료되었습니다.");
 	}
 }

--- a/src/main/java/org/bbagisix/tier/controller/TierController.java
+++ b/src/main/java/org/bbagisix/tier/controller/TierController.java
@@ -8,7 +8,6 @@ import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,14 +41,4 @@ public class TierController {
 		return ResponseEntity.ok(allTiers);
 	}
 	
-	/**
-	 * 사용자 tier 재계산 (테스트/디버깅용)
-	 * POST /api/user/me/tiers/recalculate
-	 */
-	@PostMapping("/user/me/tiers/recalculate")
-	public ResponseEntity<String> recalculateUserTier(Authentication authentication) {
-		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
-		tierService.recalculateUserTier(currentUser.getUserId());
-		return ResponseEntity.ok("Tier 재계산이 완료되었습니다.");
-	}
 }

--- a/src/main/java/org/bbagisix/user/dto/UserResponse.java
+++ b/src/main/java/org/bbagisix/user/dto/UserResponse.java
@@ -16,4 +16,5 @@ public class UserResponse {
     private String role;
 	private boolean assetConnected;
     private boolean savingConnected;
+    private Long tierId;
 }

--- a/src/main/java/org/bbagisix/user/mapper/UserMapper.java
+++ b/src/main/java/org/bbagisix/user/mapper/UserMapper.java
@@ -39,4 +39,7 @@ public interface UserMapper {
 
 	// 사용자 티어 업데이트
 	int updateUserTier(@Param("userId") Long userId, @Param("tierId") Long tierId);
+
+	// 완료한 챌린지 수 조회
+	Integer getCompletedChallengeCount(@Param("userId") Long userId);
 }

--- a/src/main/java/org/bbagisix/user/service/UserService.java
+++ b/src/main/java/org/bbagisix/user/service/UserService.java
@@ -52,6 +52,7 @@ public class UserService {
 			.role(userVO.getRole())
 			.assetConnected(userVO.isAssetConnected())
 			.savingConnected(userVO.isSavingConnected())
+			.tierId(userVO.getTierId())
 			.build();
 	}
 

--- a/src/main/resources/mappers/tier/TierMapper.xml
+++ b/src/main/resources/mappers/tier/TierMapper.xml
@@ -5,22 +5,18 @@
 
 <mapper namespace="org.bbagisix.tier.mapper.TierMapper">
 
-    <!-- 모든 티어 목록 조회 (tier_order 순서대로) -->
+    <!-- 모든 티어 목록 조회 (tier_id 순서대로) -->
     <select id="findAllTiers" resultType="org.bbagisix.tier.domain.TierVO">
         SELECT tier_id,
-               name,
-               required_success_count,
-               tier_order
+               name
         FROM tier
-        ORDER BY tier_order
+        ORDER BY tier_id
     </select>
 
     <!-- 티어 ID로 단일 티어 조회 -->
     <select id="findById" resultType="org.bbagisix.tier.domain.TierVO">
         SELECT tier_id,
-               name,
-               required_success_count,
-               tier_order
+               name
         FROM tier
         WHERE tier_id = #{tierId}
     </select>

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -82,4 +82,10 @@
         set tier_id = #{tierId}
         where user_id = #{userId}
     </update>
+
+    <select id="getCompletedChallengeCount" resultType="java.lang.Integer">
+        select count(*)
+        from user_challenge
+        where user_id = #{userId} and status = 'completed'
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
closed #188 

## ✨ 내용
- `MyPageDTO`: 원래 `MyPageAccountDTO`였지만 티어 정보 추가하면서 이름 변경함
- `MyPageService`: UserMapper로 완료한 챌린지 수 조회 로직, TierInfo 생성
- `MyPageController`: `/api/mypage/tier` 엔드포인트 추가
- `UserMapper`: user 별 완료한 챌린수 조회 쿼리 추가

티어표
| 챌린지 성공 횟수 | 티어 |
|---|---|
| 0 (default) | 아이언 |
| 1 | 브론즈 |
| 2 | 실버 |
| 3 | 골드 |
| 4 | 플래티넘 |
| 5 | 루비 |
| 6 | 에메랄드 |

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
