### PR TITLE
[FEAT] 챌린지 실패시 소비내역 호출 api 구현

### DIFF
--- a/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package org.bbagisix.challenge.controller;
 import java.util.List;
 
 import org.bbagisix.challenge.dto.ChallengeDTO;
+import org.bbagisix.challenge.dto.ChallengeFailDTO;
 import org.bbagisix.challenge.dto.ChallengeProgressDTO;
 import org.bbagisix.challenge.service.ChallengeService;
 import org.bbagisix.exception.BusinessException;
@@ -77,6 +78,26 @@ public class ChallengeController {
 			challengeService.joinChallenge(currentUser.getUserId(), challengeId, period);
 			return ResponseEntity.ok("챌린지 참여가 완료되었습니다.");
 
+		} catch (NumberFormatException e) {
+			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
+		}
+	}
+
+	// 챌린지 실패 POST /api/challenges/{challenge_id}/fail
+	@PostMapping("/{challengeId}/fail")
+	public ResponseEntity<List<ChallengeFailDTO>> failChallenge(
+		@PathVariable Long challengeId,
+		Authentication authentication) {
+
+		// challengeId 유효성 검사
+		if (challengeId == null) {
+			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
+		}
+
+		try {
+			CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
+			List<ChallengeFailDTO> failDTOList = challengeService.failChallenge(currentUser.getUserId(), challengeId);
+			return ResponseEntity.ok(failDTOList);
 		} catch (NumberFormatException e) {
 			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
 		}

--- a/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/bbagisix/challenge/controller/ChallengeController.java
@@ -101,6 +101,7 @@ public class ChallengeController {
 		} catch (NumberFormatException e) {
 			throw new BusinessException(ErrorCode.CHALLENGE_ID_REQUIRED);
 		}
+	}
 
 	@PostMapping("/close/{userChallengeId}")
 	public ResponseEntity<String> closeChallenge(@PathVariable Long userChallengeId) {

--- a/src/main/java/org/bbagisix/challenge/dto/ChallengeFailDTO.java
+++ b/src/main/java/org/bbagisix/challenge/dto/ChallengeFailDTO.java
@@ -1,0 +1,4 @@
+package org.bbagisix.challenge.dto;
+
+public class ChallengeFailDTO {
+}

--- a/src/main/java/org/bbagisix/challenge/dto/ChallengeFailDTO.java
+++ b/src/main/java/org/bbagisix/challenge/dto/ChallengeFailDTO.java
@@ -1,4 +1,17 @@
 package org.bbagisix.challenge.dto;
 
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class ChallengeFailDTO {
+	private Long amount;
+	private String description;
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+	private Date expenditureDate;
 }

--- a/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/bbagisix/challenge/mapper/ChallengeMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.bbagisix.challenge.domain.ChallengeVO;
 import org.bbagisix.challenge.domain.UserChallengeVO;
+import org.bbagisix.challenge.dto.ChallengeFailDTO;
 import org.bbagisix.challenge.dto.ChallengeProgressDTO;
 
 @Mapper
@@ -38,5 +39,6 @@ public interface ChallengeMapper {
 	// 완료된 챌린지들만 조회 (completed + failed)
 	List<UserChallengeVO> getUserCompletedChallenges(@Param("userId") Long userId);
 
+	List<ChallengeFailDTO> getFailExpenditures(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
 
 }

--- a/src/main/java/org/bbagisix/challenge/service/ChallengeService.java
+++ b/src/main/java/org/bbagisix/challenge/service/ChallengeService.java
@@ -11,6 +11,7 @@ import org.bbagisix.analytics.service.AnalyticsService;
 import org.bbagisix.challenge.domain.ChallengeVO;
 import org.bbagisix.challenge.domain.UserChallengeVO;
 import org.bbagisix.challenge.dto.ChallengeDTO;
+import org.bbagisix.challenge.dto.ChallengeFailDTO;
 import org.bbagisix.challenge.dto.ChallengeProgressDTO;
 import org.bbagisix.challenge.mapper.ChallengeMapper;
 import org.bbagisix.exception.BusinessException;
@@ -151,4 +152,10 @@ public class ChallengeService {
 			challengeMapper.updateChallenge(updated);
 		}
 	}
+
+	// 실패시 해당 카테고리 지출 내역 가져오기
+	public List<ChallengeFailDTO> failChallenge(Long userId, Long challengeId){
+		return challengeMapper.getFailExpenditures(userId, challengeId);
+	}
+
 }

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -145,4 +145,28 @@
           AND status IN ('completed', 'failed')
         ORDER BY end_date DESC, start_date DESC
     </select>
+
+    <!-- 챌린지 실패시 소비내역 조회 -->
+    <select id="getFailExpenditures" resultType="org.bbagisix.challenge.dto.ChallengeFailDTO">
+        SELECT
+            e.amount,
+            e.description,
+            e.expenditure_date as expenditureDate
+        FROM expenditure e
+                 JOIN (
+            SELECT user_id, MAX(end_date) as latest_end_date
+            FROM user_challenge
+            WHERE user_id = #{userId}
+            GROUP BY user_id
+        ) uc ON e.user_id = uc.user_id
+            AND DATE(e.expenditure_date) = DATE(uc.latest_end_date)
+        WHERE e.user_id = #{userId}
+          AND e.category_id = #{challengeId}
+          AND EXISTS (
+            SELECT 1
+            FROM user_challenge uc2
+            WHERE uc2.user_id = #{userId}
+              AND uc2.challenge_id = #{challengeId}
+        )
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#184 챌린지 실패 api 구현

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
챌린지 실패시 조인 이용해서 end_date와 카테고리 id에 해당하는 소비내역 호출 api 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
