### PR TITLE
[FEAT] 적금 상품 추천 기능 완성

### DIFF
--- a/llm-server/server.py
+++ b/llm-server/server.py
@@ -39,7 +39,7 @@ class SavingProduct(BaseModel):
 class SavingRecommendRequest(BaseModel):
     savings: List[SavingProduct]
     userAge: int
-    userJob: str
+    userRole: str
     mainBankName: str = None
 
 category_keyword_map = {
@@ -166,7 +166,7 @@ async def recommend_savings(request: SavingRecommendRequest):
     # 사용자 정보와 적금 상품 리스트를 기반으로 추천
     user_info = {
         "age": request.userAge,
-        "job": request.userJob,
+        "role": request.userRole,
         "mainBank": request.mainBankName or "없음"
     }
     
@@ -190,9 +190,14 @@ async def recommend_savings(request: SavingRecommendRequest):
 추천 기준:
 1. 사용자 나이와 가입대상 적합성
 2. 사용자 직업과 상품 특성 매칭
-3. 주거래은행과의 연관성 (우대금리 혜택)
-4. 금리 경쟁력 (기본금리 + 우대금리)
-5. 특별조건의 달성 가능성
+3. 금리 경쟁력 (기본금리 + 우대금리)
+4. 특별조건의 달성 가능성
+5. 은행 다양성 (가능한 다른 은행 상품 포함)
+
+추천 원칙:
+- 주거래은행 상품이 있고 조건이 좋다면 2개까지 포함 가능
+- 나머지는 다른 은행의 경쟁력 있는 상품으로 구성
+- 최대한 다양한 은행에서 선택하여 포트폴리오 다양화
 
 출력 형식: 상품코드 3개를 쉼표로 구분하여 출력 (예: 00266451,00123456,00789012)
 반드시 제공된 상품 목록에서만 선택하세요."""
@@ -212,8 +217,9 @@ async def recommend_savings(request: SavingRecommendRequest):
 추천 조건:
 - 사용자가 실제 가입 가능한 상품만 선택
 - 금리가 높고 조건이 유리한 상품 우선
-- 주거래은행 상품이 있다면 우대 혜택 고려
+- 주거래은행 상품은 최대 2개까지 포함 (다른 은행 상품도 반드시 포함)
 - 사용자 직업/연령대에 맞는 상품 우선
+- 서로 다른 은행 상품으로 구성하여 다양성 확보
 
 상위 3개 추천 상품의 상품코드만 쉼표로 구분하여 출력:"""
         }

--- a/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
+++ b/src/main/java/org/bbagisix/analytics/service/AnalyticsServiceImpl.java
@@ -9,6 +9,7 @@ import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
 import org.bbagisix.expense.domain.ExpenseVO;
 import org.bbagisix.expense.service.ExpenseService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -23,7 +24,9 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 	private final ExpenseService expenseService;
 	private final CategoryService categoryService;
 	private final RestTemplate restTemplate = new RestTemplate();
-	private static final String URL = "http://llm-server:8000/analysis";
+	
+	@Value("${LLM_SERVER_URL}")
+	private String llmServerUrl;
 
 	@Override
 	public List<Long> getTopCategories(Long userId) {
@@ -42,7 +45,8 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 
 			Map<String, Object> payload = Map.of("exps", expsForAnalytics);
 
-			Map<String, Object> response = restTemplate.postForObject(URL, payload, Map.class);
+			String analysisUrl = llmServerUrl + "/analysis";
+			Map<String, Object> response = restTemplate.postForObject(analysisUrl, payload, Map.class);
 			if (response == null || !response.containsKey("results")) {
 				throw new BusinessException(ErrorCode.LLM_ANALYTICS_ERROR);
 			}

--- a/src/main/java/org/bbagisix/classify/service/ClassifyServiceImpl.java
+++ b/src/main/java/org/bbagisix/classify/service/ClassifyServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.bbagisix.exception.BusinessException;
 import org.bbagisix.exception.ErrorCode;
 import org.bbagisix.expense.domain.ExpenseVO;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,7 +21,9 @@ import lombok.extern.log4j.Log4j2;
 public class ClassifyServiceImpl implements ClassifyService {
 
 	private final RestTemplate restTemplate = new RestTemplate();
-	private static final String URL = "http://llm-server:8000/classify";
+	
+	@Value("${LLM_SERVER_URL}")
+	private String llmServerUrl;
 
 	@Override
 	public List<ExpenseVO> classify(List<ExpenseVO> expenses) {
@@ -50,7 +53,8 @@ public class ClassifyServiceImpl implements ClassifyService {
 
 		Map<String, Object> payload = Map.of("exps", exps);
 
-		Map<String, Object> response = restTemplate.postForObject(URL, payload, Map.class);
+		String classifyUrl = llmServerUrl + "/classify";
+		Map<String, Object> response = restTemplate.postForObject(classifyUrl, payload, Map.class);
 		if (response == null || !response.containsKey("results")) {
 			throw new BusinessException(ErrorCode.LLM_CLASSIFY_ERROR);
 		}

--- a/src/main/java/org/bbagisix/finproduct/controller/FinProductController.java
+++ b/src/main/java/org/bbagisix/finproduct/controller/FinProductController.java
@@ -3,7 +3,6 @@ package org.bbagisix.finproduct.controller;
 import org.bbagisix.finproduct.dto.RecommendedSavingDTO;
 import org.bbagisix.finproduct.service.FinProductService;
 import org.bbagisix.finproduct.service.RecommendationService;
-import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -39,21 +38,13 @@ public class FinProductController {
 	}
 
 	// 사용자 맞춤 적금상품 추천 조회
-	// 하이브리드 방식: 백엔드 1차 필터링된 결과를 반환 (향후 LLM 연동 예정)
+	// 하이브리드 방식: 백엔드 1차 필터링 + LLM 2차 지능형 추천
 	@GetMapping("/recommend")
 	public ResponseEntity<List<RecommendedSavingDTO>> getRecommendedSavings(
 		Authentication authentication,
 		@RequestParam(value = "limit", required = false) Integer limit) {
 
-		CustomOAuth2User currentUser = (CustomOAuth2User)authentication.getPrincipal();
-		Long userId = currentUser.getUserId();
-
-		log.info("사용자 {}에 대한 적금상품 추천 API 호출 - limit: {}", userId, limit);
-
-		// 1차 필터링된 상품 조회 (limit 파라미터로 통합 처리)
-		List<RecommendedSavingDTO> recommendations = recommendationService.getFilteredSavings(userId, limit);
-
-		log.info("사용자 {}에 대한 적금상품 추천 API 완료 - {}개 상품", userId, recommendations.size());
+		List<RecommendedSavingDTO> recommendations = recommendationService.getRecommendedSavings(authentication, limit);
 
 		return ResponseEntity.ok(recommendations);
 	}

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingProductDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingProductDTO.java
@@ -1,13 +1,17 @@
 package org.bbagisix.finproduct.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
-// 적금 상품 정보
+@NoArgsConstructor
+@AllArgsConstructor
+// LLM 서버와 통신용 적금 상품 정보 (요청/응답 공용)
 public class LlmSavingProductDTO {
     private String finPrdtCd;
     private String korCoNm;

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingProductDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingProductDTO.java
@@ -1,0 +1,19 @@
+package org.bbagisix.finproduct.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+// 적금 상품 정보
+public class LlmSavingProductDTO {
+    private String finPrdtCd;
+    private String korCoNm;
+    private String finPrdtNm;
+    private String spclCnd;
+    private String joinMember;
+    private double intrRate;
+    private double intrRate2;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingRequestDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingRequestDTO.java
@@ -1,0 +1,18 @@
+package org.bbagisix.finproduct.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+// LLM 서버 요청 데이터
+public class LlmSavingRequestDTO {
+    private List<LlmSavingProductDTO> savings;
+    private int userAge;
+    private String userRole;
+    private String mainBankName;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingRequestDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingRequestDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-// LLM 서버 요청 데이터
+// LLM 서버로 보내는 추천 요청 데이터 (상품리스트 + 사용자정보)
 public class LlmSavingRequestDTO {
     private List<LlmSavingProductDTO> savings;
     private int userAge;

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingResponseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingResponseDTO.java
@@ -1,0 +1,13 @@
+package org.bbagisix.finproduct.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+// LLM 서버 응답 데이터
+public class LlmSavingResponseDTO {
+    private List<RecommendedSavingDTO> recommendations;
+}

--- a/src/main/java/org/bbagisix/finproduct/dto/LlmSavingResponseDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/LlmSavingResponseDTO.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @Setter
-// LLM 서버 응답 데이터
+// LLM 서버에서 받는 추천 응답 데이터 (추천된 상품리스트)
 public class LlmSavingResponseDTO {
-    private List<RecommendedSavingDTO> recommendations;
+    private List<LlmSavingProductDTO> recommendations;
 }

--- a/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.math.BigDecimal;
 
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+// API 응답용 적금 상품 정보 (사용자 정보는 내부 처리용)
 public class RecommendedSavingDTO {
     private String finPrdtCd;      // 금융상품 코드
     private String korCoNm;        // 금융회사 명
@@ -22,8 +24,11 @@ public class RecommendedSavingDTO {
     private BigDecimal intrRate;       // 저축 금리
     private BigDecimal intrRate2;      // 최고 우대금리
     
-    // 사용자 정보 (LLM 추천용)
+    // 사용자 정보 (LLM 추천용, JSON 응답에서 제외)
+    @JsonIgnore
     private Integer userAge;       // 사용자 나이
+    @JsonIgnore
     private String userJob;        // 사용자 직업
+    @JsonIgnore
     private String mainBankName;   // 주거래은행
 }

--- a/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
+++ b/src/main/java/org/bbagisix/finproduct/dto/RecommendedSavingDTO.java
@@ -21,4 +21,9 @@ public class RecommendedSavingDTO {
     private String joinMember;     // 가입 대상
     private BigDecimal intrRate;       // 저축 금리
     private BigDecimal intrRate2;      // 최고 우대금리
+    
+    // 사용자 정보 (LLM 추천용)
+    private Integer userAge;       // 사용자 나이
+    private String userJob;        // 사용자 직업
+    private String mainBankName;   // 주거래은행
 }

--- a/src/main/java/org/bbagisix/finproduct/service/FinProductService.java
+++ b/src/main/java/org/bbagisix/finproduct/service/FinProductService.java
@@ -8,6 +8,7 @@ import org.bbagisix.finproduct.dto.FssApiResponseDTO;
 import org.bbagisix.finproduct.dto.ProductBaseDTO;
 import org.bbagisix.finproduct.dto.ProductOptionDTO;
 import org.bbagisix.finproduct.mapper.FinProductMapper;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class FinProductService {
     private final FinProductMapper finProductMapper;
     
     // 금감원 API 데이터를 동기화하여 DB에 저장
+    @Scheduled(cron = "0 0 4 ? * MON") // 매주 월요일 오전 4시에 실행
     @Transactional
     public void syncFinProductData() {
         try {

--- a/src/main/java/org/bbagisix/finproduct/service/RecommendationService.java
+++ b/src/main/java/org/bbagisix/finproduct/service/RecommendationService.java
@@ -7,12 +7,14 @@ import org.bbagisix.finproduct.dto.LlmSavingRequestDTO;
 import org.bbagisix.finproduct.dto.LlmSavingResponseDTO;
 import org.bbagisix.finproduct.dto.RecommendedSavingDTO;
 import org.bbagisix.finproduct.mapper.FinProductMapper;
+import org.bbagisix.user.dto.CustomOAuth2User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -35,6 +37,16 @@ public class RecommendationService {
     
     @Value("${LLM_SERVER_URL}")
     private String llmServerUrl;
+
+    // Authentication에서 사용자 ID 추출하여 추천 서비스 호출
+    public List<RecommendedSavingDTO> getRecommendedSavings(Authentication authentication, Integer limit) {
+        CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = currentUser.getUserId();
+        
+        log.info("사용자 {}에 대한 적금상품 추천 API 호출 - limit: {}", userId, limit);
+        
+        return getFilteredSavings(userId, limit);
+    }
 
     // 사용자 맞춤 적금상품 추천 (하이브리드 방식)
     // 1차: DB 필터링 → 2차: LLM 지능형 추천

--- a/src/main/resources/mappers/finproduct/FinProductMapper.xml
+++ b/src/main/resources/mappers/finproduct/FinProductMapper.xml
@@ -55,52 +55,69 @@
     </select>
 
     <!-- 추천 적금 상품 조회 (1차 백엔드 필터링) -->
+    <!-- finPrdtCd별로 중복 제거하여 intrRate 최소값, intrRate2 최대값 추출 -->
     <select id="findRecommendedSavings" resultType="org.bbagisix.finproduct.dto.RecommendedSavingDTO">
         SELECT 
-            b.fin_prdt_cd as finPrdtCd,
-            b.kor_co_nm as korCoNm,
-            b.fin_prdt_nm as finPrdtNm,
-            b.spcl_cnd as spclCnd,
-            b.join_member as joinMember,
-            o.intr_rate as intrRate,
-            o.intr_rate2 as intrRate2,
-            u.age as userAge,
-            u.role as userJob,
-            SUBSTRING_INDEX(a.bank_name, '은행', 1) as mainBankName
-        FROM saving_base b
-        INNER JOIN saving_option o ON b.saving_base_id = o.saving_base_id
-        INNER JOIN user u ON u.user_id = #{userId}
-        LEFT JOIN user_asset a ON a.user_id = #{userId} AND a.status = 'main'
-        WHERE 1=1
-        
-        <!-- 1차 필터링: 명백한 불가능 케이스 제외 -->
-        
-        <!-- 나이 제한 필터 - CDATA로 XML 특수문자 처리 -->
-        AND (
-            b.join_member NOT LIKE '%세%'  -- 나이 제한 없는 상품
-            OR 
-            <![CDATA[
-            -- "만 XX세 이상" 패턴
-            (b.join_member LIKE '%만%세%이상%' AND 
-             u.age >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1) AS UNSIGNED))
-            OR
-            -- "만 XX세 이하" 패턴  
-            (b.join_member LIKE '%만%세%이하%' AND
-             u.age <= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1) AS UNSIGNED))
-            OR
-            -- "만 XX세부터 만 YY세까지" 범위 패턴
-            (b.join_member REGEXP '만[[:space:]]*[0-9]+세.*만[[:space:]]*[0-9]+세' AND
-             u.age >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', 2), '세', 1) AS UNSIGNED) AND
-             u.age <= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1), '까지', 1) AS UNSIGNED))
-            ]]>
-        )
-        
-        <!-- 직업 제한 필터 -->
-        AND (
-            (u.role = '직장인' AND b.spcl_cnd NOT LIKE '%군인%' AND b.spcl_cnd NOT LIKE '%경찰%' AND b.join_member NOT LIKE '%학생%')
-            OR (u.role = '학생' AND b.join_member NOT LIKE '%직장인%' AND b.join_member NOT LIKE '%재직자%')
-            OR (u.role NOT IN ('직장인', '학생'))
-        )
+            filtered.fin_prdt_cd as finPrdtCd,
+            filtered.kor_co_nm as korCoNm,
+            filtered.fin_prdt_nm as finPrdtNm,
+            filtered.spcl_cnd as spclCnd,
+            filtered.join_member as joinMember,
+            filtered.min_intr_rate as intrRate,
+            filtered.max_intr_rate2 as intrRate2,
+            filtered.userAge as userAge,
+            filtered.userJob as userJob,
+            filtered.mainBankName as mainBankName
+        FROM (
+            SELECT 
+                b.fin_prdt_cd,
+                b.kor_co_nm,
+                b.fin_prdt_nm,
+                b.spcl_cnd,
+                b.join_member,
+                MIN(o.intr_rate) as min_intr_rate,
+                MAX(o.intr_rate2) as max_intr_rate2,
+                u.age as userAge,
+                u.role as userJob,
+                SUBSTRING_INDEX(a.bank_name, '은행', 1) as mainBankName
+            FROM saving_base b
+            INNER JOIN saving_option o ON b.saving_base_id = o.saving_base_id
+            INNER JOIN user u ON u.user_id = #{userId}
+            LEFT JOIN user_asset a ON a.user_id = #{userId} AND a.status = 'main'
+            WHERE 1=1
+            
+            <!-- 1차 필터링: 명백한 불가능 케이스 제외 -->
+            
+            <!-- 나이 제한 필터 - CDATA로 XML 특수문자 처리 -->
+            AND (
+                b.join_member NOT LIKE '%세%'  -- 나이 제한 없는 상품
+                OR 
+                <![CDATA[
+                -- "만 XX세 이상" 패턴
+                (b.join_member LIKE '%만%세%이상%' AND 
+                 u.age >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1) AS UNSIGNED))
+                OR
+                -- "만 XX세 이하" 패턴  
+                (b.join_member LIKE '%만%세%이하%' AND
+                 u.age <= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1) AS UNSIGNED))
+                OR
+                -- "만 XX세부터 만 YY세까지" 범위 패턴
+                (b.join_member REGEXP '만[[:space:]]*[0-9]+세.*만[[:space:]]*[0-9]+세' AND
+                 u.age >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', 2), '세', 1) AS UNSIGNED) AND
+                 u.age <= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(b.join_member, '만', -1), '세', 1), '까지', 1) AS UNSIGNED))
+                ]]>
+            )
+            
+            <!-- 직업 제한 필터 -->
+            AND (
+                (u.role = '직장인' AND b.spcl_cnd NOT LIKE '%군인%' AND b.spcl_cnd NOT LIKE '%경찰%' AND b.join_member NOT LIKE '%학생%')
+                OR (u.role = '학생' AND b.join_member NOT LIKE '%직장인%' AND b.join_member NOT LIKE '%재직자%')
+                OR (u.role NOT IN ('직장인', '학생'))
+            )
+            
+            <!-- finPrdtCd별로 그룹화하여 중복 제거 -->
+            GROUP BY b.fin_prdt_cd, b.kor_co_nm, b.fin_prdt_nm, b.spcl_cnd, b.join_member, u.age, u.role, a.bank_name
+        ) filtered
         
         <if test="limit != null and limit > 0">
             LIMIT #{limit}


### PR DESCRIPTION
## 📌 관련 이슈
closed #189 

## ✨ 내용
금융감독원 적금 상품 데이터를 DB에 저장, 사용자의 기본 조건에 따라 1차 필터링
데이터 동기화: 스케쥴러를 이용해 매주 월요일 4시에 업데이트 -> 금융 상품 정보를 최신 상태로 유지
상품 추천: LLM을 연동해 1차 필터링된 상품 목록 중 사용자에 가장 적합한 상품 추천

## 📸 스크린샷(선택)
<img width="1916" height="813" alt="스크린샷 2025-08-13 174259" src="https://github.com/user-attachments/assets/1f8d3920-afaf-432c-a8cf-caaaa792e365" />

하드 코딩된 llm-server 수정하였음 (노션 api_key의 application.properties에 반영)
