### PR TITLE
[FEAT] 기존 스케쥴러 활용한 수동 새로고침 및 사용자 생성,수정 보존 시스템

### DIFF
--- a/src/main/java/org/bbagisix/asset/service/AssetService.java
+++ b/src/main/java/org/bbagisix/asset/service/AssetService.java
@@ -233,10 +233,25 @@ public class AssetService {
 				);
 				expenseVO.setExpenditureDate(expenditureDate);
 
+				// Codef 자동 생성 거래 설정
+				expenseVO.setUserModified(false);
+				// Codef transaction ID 생성 (날짜+시간+금액+설명 기반)
+				String codefTransactionId = generateCodefTransactionId(item);
+				expenseVO.setCodefTransactionId(codefTransactionId);
+
 				expenses.add(expenseVO);
 			}
 		}
 		return expenses;
+	}
+
+	// Codef transaction ID 생성
+	private String generateCodefTransactionId(CodefTransactionResDTO.HistoryItem item) {
+		return String.format("CODEF_%s_%s_%s_%s",
+			item.getResAccountTrDate(),
+			item.getResAccountTrTime(),
+			item.getResAccountOut() != null ? item.getResAccountOut() : item.getResAccountIn(),
+			item.getResAccountDesc3() != null ? item.getResAccountDesc3().hashCode() : "0");
 	}
 
 	// 금액 문자열을 Long으로 변환

--- a/src/main/java/org/bbagisix/codef/service/CodefSchedulerService.java
+++ b/src/main/java/org/bbagisix/codef/service/CodefSchedulerService.java
@@ -69,6 +69,19 @@ public class CodefSchedulerService {
 		log.info("Scheduler finish - success: {}, fail: {}", successCount, failCount);
 	}
 
+	// 개별 사용자 거래내역 동기화 (새로고침용)
+	@Transactional
+	public void syncUserTransactions(Long userId) {
+		AssetVO mainAsset = assetMapper.selectAssetByUserIdAndStatus(userId, "main");
+		if (mainAsset != null) {
+			log.info("User {} transaction sync start", userId);
+			syncAssetTransactions(mainAsset);
+			log.info("User {} transaction sync completed", userId);
+		} else {
+			log.warn("User {} has no main asset", userId);
+		}
+	}
+
 	// 단일 계좌의 거래내역 동기화
 	private void syncAssetTransactions(AssetVO asset) {
 		// AssetDTO 생성

--- a/src/main/java/org/bbagisix/exception/ErrorCode.java
+++ b/src/main/java/org/bbagisix/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 	EXPENSE_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EX003", "소비내역 생성에 실패했습니다."),
 	EXPENSE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EX004", "소비내역 수정에 실패했습니다."),
 	EXPENSE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EX005", "소비내역 삭제에 실패했습니다."),
+	EXPENSE_SUMMARY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EX006", "지출 집계 조회에 실패했습니다."),
 
 	// LLM 관련 에러
 	LLM_CLASSIFY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "L001", "카테고리 분류에 실패했습니다."),

--- a/src/main/java/org/bbagisix/expense/controller/ExpenseController.java
+++ b/src/main/java/org/bbagisix/expense/controller/ExpenseController.java
@@ -1,6 +1,7 @@
 package org.bbagisix.expense.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bbagisix.category.dto.CategoryDTO;
 import org.bbagisix.category.service.CategoryService;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.core.Authentication;
 import org.bbagisix.user.dto.CustomOAuth2User;
@@ -70,5 +72,19 @@ public class ExpenseController {
 	@GetMapping("/categories")
 	public ResponseEntity<List<CategoryDTO>> getAllCategories() {
 		return ResponseEntity.ok(categoryService.getAllCategories());
+	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<String> refreshExpensesFromCodef(Authentication authentication) {
+		CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+		expenseService.refreshFromCodef(currentUser.getUserId());
+		return ResponseEntity.ok("거래내역 새로고침이 완료되었습니다.");
+	}
+
+	@GetMapping("/current-month-summary")
+	public ResponseEntity<Map<String, Long>> getCurrentMonthSummary(Authentication authentication) {
+		CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+		Map<String, Long> summary = expenseService.getCurrentMonthSummary(currentUser.getUserId());
+		return ResponseEntity.ok(summary);
 	}
 }

--- a/src/main/java/org/bbagisix/expense/domain/ExpenseVO.java
+++ b/src/main/java/org/bbagisix/expense/domain/ExpenseVO.java
@@ -29,4 +29,7 @@ public class ExpenseVO {
 	private Date expenditureDate;
 	private Date createdAt;
 	private Date updatedAt;
+	private Boolean userModified;
+	private String codefTransactionId;
+	private Date deletedAt;
 }

--- a/src/main/java/org/bbagisix/expense/dto/ExpenseDTO.java
+++ b/src/main/java/org/bbagisix/expense/dto/ExpenseDTO.java
@@ -26,6 +26,7 @@ public class ExpenseDTO {
 	private String bankName;
 	private Date createdAt;
 	private Date updatedAt;
+	private Boolean userModified;
 
 	// 요청/응답 공통 필드
 	private Long userId;

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -39,5 +39,5 @@ public interface ExpenseMapper {
 	int softDelete(Long expenditureId, Long userId);
 
 	// 현재월 카테고리별 지출 집계
-	Map<String, Long> getCurrentMonthSummaryByCategory(Long userId);
+	List<Map<String, Object>> getCurrentMonthSummaryByCategory(Long userId);
 }

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -1,6 +1,7 @@
 package org.bbagisix.expense.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -40,4 +41,7 @@ public interface ExpenseMapper {
 
 	// 내역을 물리적 삭제 대신 소프트 삭제
 	int softDelete(Long expenditureId, Long userId);
+
+	// 현재월 카테고리별 지출 집계
+	Map<String, Long> getCurrentMonthSummaryByCategory(Long userId);
 }

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -31,4 +31,13 @@ public interface ExpenseMapper {
 		@Param("period") Long period);
 
 	int insertExpenses(List<ExpenseVO> expenses);
+
+	// codef 거래 ID로 중복 개수 확인
+	int countByCodefTransactionId(String codefTransactionId);
+
+	// codef 거래 ID로 실제 거래 데이터 조회
+	List<ExpenseVO> findByCodefTransactionId(String codefTransactionId);
+
+	// 내역을 물리적 삭제 대신 소프트 삭제
+	int softDelete(Long expenditureId, Long userId);
 }

--- a/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
+++ b/src/main/java/org/bbagisix/expense/mapper/ExpenseMapper.java
@@ -15,13 +15,9 @@ public interface ExpenseMapper {
 
 	ExpenseVO findById(Long expenditureId);
 
-	List<ExpenseVO> findAllByUserId(Long userId);
-
 	List<ExpenseDTO> findAllByUserIdWithDetails(Long userId);
 
 	int update(ExpenseVO expense);
-
-	int delete(Long expenditureId, Long userId);
 
 	List<ExpenseVO> getRecentExpenses(Long userId);
 

--- a/src/main/java/org/bbagisix/expense/service/ExpenseService.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseService.java
@@ -1,6 +1,7 @@
 package org.bbagisix.expense.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bbagisix.expense.domain.ExpenseVO;
 import org.bbagisix.expense.dto.ExpenseDTO;
@@ -21,4 +22,10 @@ public interface ExpenseService {
 	// 시스템 내부 호출용 메서드 (권한 검증 없음)
 	ExpenseDTO getExpenseByIdInternal(Long expenditureId);
 	ExpenseDTO updateExpenseInternal(Long expenditureId, ExpenseDTO expenseDTO);
+
+	// Codef 동기화
+	void refreshFromCodef(Long userId);
+
+	// 현재월 카테고리별 지출 집계
+	Map<String, Long> getCurrentMonthSummary(Long userId);
 }

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -266,7 +266,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			return expenseMapper.getCurrentMonthSummaryByCategory(userId);
 		} catch (Exception e) {
 			log.error("현재월 지출 집계 조회 중 오류 발생: userId={}, error={}", userId, e.getMessage(), e);
-			throw new BusinessException(ErrorCode.DATA_ACCESS_ERROR, "지출 집계 조회에 실패했습니다.");
+			throw new BusinessException(ErrorCode.EXPENSE_SUMMARY_FAILED, "지출 집계 조회에 실패했습니다.");
 		}
 	}
 }

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -1,6 +1,7 @@
 package org.bbagisix.expense.service;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -263,7 +264,22 @@ public class ExpenseServiceImpl implements ExpenseService {
 	@Override
 	public Map<String, Long> getCurrentMonthSummary(Long userId) {
 		try {
-			return expenseMapper.getCurrentMonthSummaryByCategory(userId);
+			List<Map<String, Object>> results = expenseMapper.getCurrentMonthSummaryByCategory(userId);
+			Map<String, Long> summary = new HashMap<>();
+			
+			for (Map<String, Object> row : results) {
+				String categoryName = (String) row.get("key");
+				Object amountObj = row.get("value");
+				Long amount = 0L;
+				
+				if (amountObj instanceof Number) {
+					amount = ((Number) amountObj).longValue();
+				}
+				
+				summary.put(categoryName, amount);
+			}
+			
+			return summary;
 		} catch (Exception e) {
 			log.error("현재월 지출 집계 조회 중 오류 발생: userId={}, error={}", userId, e.getMessage(), e);
 			throw new BusinessException(ErrorCode.EXPENSE_SUMMARY_FAILED, "지출 집계 조회에 실패했습니다.");

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -256,7 +256,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			codefSchedulerService.syncUserTransactions(userId);
 		} catch (Exception e) {
 			log.error("Codef 동기화 중 오류 발생: userId={}, error={}", userId, e.getMessage(), e);
-			throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR, "거래내역 새로고침에 실패했습니다.");
+			throw new BusinessException(ErrorCode.EXPENSE_SUMMARY_FAILED, "거래내역 새로고침에 실패했습니다.");
 		}
 	}
 

--- a/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/org/bbagisix/expense/service/ExpenseServiceImpl.java
@@ -40,6 +40,8 @@ public class ExpenseServiceImpl implements ExpenseService {
 			expenseDTO.setAssetId(mainAsset.getAssetId());
 			
 			ExpenseVO vo = dtoToVo(expenseDTO);
+			// 사용자 직접 생성시 true 설정
+			vo.setUserModified(true);
 			expenseMapper.insert(vo);
 			if (vo.getExpenditureId() == null) {
 				throw new BusinessException(ErrorCode.EXPENSE_CREATE_FAILED);
@@ -104,6 +106,8 @@ public class ExpenseServiceImpl implements ExpenseService {
 			vo.setAmount(expenseDTO.getAmount());
 			vo.setDescription(expenseDTO.getDescription());
 			vo.setExpenditureDate(expenseDTO.getExpenditureDate());
+			// 수정 시 user_modified = true 자동 설정
+			vo.setUserModified(true);
 			vo.setUserId(userId); // WHERE 조건을 위해 필요
 
 			int result = expenseMapper.update(vo);
@@ -130,7 +134,8 @@ public class ExpenseServiceImpl implements ExpenseService {
 			if (!vo.getUserId().equals(userId)) {
 				throw new BusinessException(ErrorCode.EXPENSE_ACCESS_DENIED);
 			}
-			int result = expenseMapper.delete(expenditureId, userId);
+			// 삭제 시 softDelete() 메서드 사용
+			int result = expenseMapper.softDelete(expenditureId, userId);
 			if (result != 1) {
 				throw new BusinessException(ErrorCode.EXPENSE_DELETE_FAILED, 
 					"예상 삭제 수: 1, 실제: " + result);
@@ -224,6 +229,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 			.expenditureDate(vo.getExpenditureDate())
 			.createdAt(vo.getCreatedAt())
 			.updatedAt(vo.getUpdatedAt())
+			.userModified(vo.getUserModified())
 			.build();
 
 		if (vo.getCategoryId() != null) {

--- a/src/main/resources/mappers/asset/AssetMapper.xml
+++ b/src/main/resources/mappers/asset/AssetMapper.xml
@@ -136,6 +136,7 @@
           AND amount = #{amount}
           AND description = #{description}
           AND DATE_FORMAT(expenditure_date, '%Y-%m-%d %H:%i') = DATE_FORMAT(#{expenditureDate}, '%Y-%m-%d %H:%i')
+          AND deleted_at IS NULL
     </select>
 
     <!-- 저금통 계좌 잔액 업데이트 (동시성 문제 때문에 따로 만듦) -->

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -28,25 +28,6 @@
           AND deleted_at IS NULL
     </select>
 
-    <select id="findAllByUserId" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
-        SELECT expenditure_id,
-               user_id,
-               category_id,
-               asset_id,
-               amount,
-               description,
-               expenditure_date,
-               created_at,
-               updated_at,
-               user_modified,
-               codef_transaction_id,
-               deleted_at
-        FROM expenditure
-        WHERE user_id = #{userId}
-          AND deleted_at IS NULL
-        ORDER BY expenditure_date DESC
-    </select>
-
     <select id="findAllByUserIdWithDetails" parameterType="long" resultType="org.bbagisix.expense.dto.ExpenseDTO">
         SELECT e.expenditure_id as expenditureId,
                e.user_id as userId,
@@ -80,12 +61,6 @@
           AND deleted_at IS NULL
     </update>
 
-    <delete id="delete">
-        DELETE
-        FROM expenditure
-        WHERE expenditure_id = #{param1}
-          AND user_id = #{param2}
-    </delete>
 
     <select id="getRecentExpenses" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
         SELECT *

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -6,8 +6,8 @@
 <mapper namespace="org.bbagisix.expense.mapper.ExpenseMapper">
     <insert id="insert" parameterType="org.bbagisix.expense.domain.ExpenseVO" useGeneratedKeys="true"
             keyProperty="expenditureId">
-        INSERT INTO expenditure (user_id, category_id, asset_id, amount, description, expenditure_date)
-        VALUES (#{userId}, #{categoryId}, #{assetId}, #{amount}, #{description}, #{expenditureDate})
+        INSERT INTO expenditure (user_id, category_id, asset_id, amount, description, expenditure_date, user_modified, codef_transaction_id)
+        VALUES (#{userId}, #{categoryId}, #{assetId}, #{amount}, #{description}, #{expenditureDate}, #{userModified}, #{codefTransactionId})
     </insert>
 
     <select id="findById" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
@@ -19,9 +19,13 @@
                description,
                expenditure_date,
                created_at,
-               updated_at
+               updated_at,
+               user_modified,
+               codef_transaction_id,
+               deleted_at
         FROM expenditure
         WHERE expenditure_id = #{expenditureId}
+          AND deleted_at IS NULL
     </select>
 
     <select id="findAllByUserId" parameterType="long" resultType="org.bbagisix.expense.domain.ExpenseVO">
@@ -33,9 +37,13 @@
                description,
                expenditure_date,
                created_at,
-               updated_at
+               updated_at,
+               user_modified,
+               codef_transaction_id,
+               deleted_at
         FROM expenditure
         WHERE user_id = #{userId}
+          AND deleted_at IS NULL
         ORDER BY expenditure_date DESC
     </select>
 
@@ -55,7 +63,7 @@
         FROM expenditure e
         LEFT JOIN category c ON e.category_id = c.category_id
         LEFT JOIN user_asset a ON e.asset_id = a.asset_id
-        WHERE e.user_id = #{userId} AND a.status = 'main'
+        WHERE e.user_id = #{userId} AND a.status = 'main' AND e.deleted_at IS NULL
         ORDER BY e.expenditure_date DESC
     </select>
 
@@ -65,9 +73,11 @@
             asset_id         = #{assetId},
             amount           = #{amount},
             description      = #{description},
-            expenditure_date = #{expenditureDate}
+            expenditure_date = #{expenditureDate},
+            user_modified    = TRUE
         WHERE expenditure_id = #{expenditureId}
           AND user_id = #{userId}
+          AND deleted_at IS NULL
     </update>
 
     <delete id="delete">
@@ -82,6 +92,7 @@
         FROM expenditure
         WHERE user_id = #{userId}
           AND expenditure_date >= DATE_SUB(CURDATE(), INTERVAL 2 MONTH)
+          AND deleted_at IS NULL
         ORDER BY expenditure_date DESC
     </select>
 
@@ -90,6 +101,7 @@
         FROM expenditure
         WHERE user_id = #{userId}
           AND DATE (expenditure_date)=CURDATE()
+          AND deleted_at IS NULL
     </select>
 
     <select id="getSumOfPeriodExpenses" resultType="long">
@@ -100,6 +112,7 @@
           AND expenditure_date
             BETWEEN DATE_SUB(CURDATE() - INTERVAL 1 DAY, INTERVAL #{period} DAY)
             AND (CURDATE() - INTERVAL 1 DAY)
+          AND deleted_at IS NULL
     </select>
 
     <insert id="insertExpenses" parameterType="java.util.List">
@@ -110,7 +123,9 @@
             amount,
             description,
             expenditure_date,
-            created_at
+            created_at,
+            user_modified,
+            codef_transaction_id
         ) VALUES
         <foreach collection="list" item="expense" separator=",">
             (
@@ -120,8 +135,44 @@
                 #{expense.amount},
                 #{expense.description},
                 #{expense.expenditureDate},
-                NOW()
+                NOW(),
+                COALESCE(#{expense.userModified}, FALSE),
+                #{expense.codefTransactionId}
             )
         </foreach>
     </insert>
+
+    <select id="countByCodefTransactionId" parameterType="string" resultType="int">
+        SELECT COUNT(*)
+        FROM expenditure
+        WHERE codef_transaction_id = #{codefTransactionId}
+          AND deleted_at IS NULL
+    </select>
+
+    <select id="findByCodefTransactionId" parameterType="string" resultType="org.bbagisix.expense.domain.ExpenseVO">
+        SELECT expenditure_id,
+               user_id,
+               category_id,
+               asset_id,
+               amount,
+               description,
+               expenditure_date,
+               created_at,
+               updated_at,
+               user_modified,
+               codef_transaction_id,
+               deleted_at
+        FROM expenditure
+        WHERE codef_transaction_id = #{codefTransactionId}
+          AND deleted_at IS NULL
+    </select>
+
+    <update id="softDelete">
+        UPDATE expenditure
+        SET deleted_at = NOW(),
+            user_modified = TRUE
+        WHERE expenditure_id = #{param1}
+          AND user_id = #{param2}
+          AND deleted_at IS NULL
+    </update>
 </mapper>

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -152,7 +152,7 @@
     </update>
 
     <select id="getCurrentMonthSummaryByCategory" parameterType="long" resultType="map">
-        SELECT c.name as key, SUM(e.amount) as value
+        SELECT c.name as `key`, SUM(e.amount) as `value`
         FROM expenditure e 
         JOIN category c ON e.category_id = c.category_id
         WHERE e.user_id = #{userId} 

--- a/src/main/resources/mappers/expense/ExpenseMapper.xml
+++ b/src/main/resources/mappers/expense/ExpenseMapper.xml
@@ -175,4 +175,15 @@
           AND user_id = #{param2}
           AND deleted_at IS NULL
     </update>
+
+    <select id="getCurrentMonthSummaryByCategory" parameterType="long" resultType="map">
+        SELECT c.name as key, SUM(e.amount) as value
+        FROM expenditure e 
+        JOIN category c ON e.category_id = c.category_id
+        WHERE e.user_id = #{userId} 
+          AND YEAR(e.expenditure_date) = YEAR(NOW())
+          AND MONTH(e.expenditure_date) = MONTH(NOW())
+          AND e.deleted_at IS NULL
+        GROUP BY c.name
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
closed #199 

## ✨ 내용
기존 스케줄러의 codef API 동기화 로직을 활용해 사용자가 수동으로 내역을 받아올 수 있는 엔드포인트 추가.
사용자 생성, 수정, 삭제 내역 보존 시스템 구현: 원래 로직 대로면 codef 호출 시 수정한 내용이 다시 원상 복구 될 가능성, 삭제해도 코데프에서 다시 가져옴. 
삭제는 소프트 딜리트로 구현(deleted_at)
사용하지 않는 mapper 제거.
