### PR TITLE
[FIX] 배포 환경에서 채팅 연결 안됨

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
 
         # WebSocket 전용 location
-        location /api/ws {
+        location /api/ws/ {
             set $upstream_server dondothat-server:8080;
             proxy_pass http://$upstream_server;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
 
         # WebSocket 전용 location
-        location /api/ws/ {
+        location /ws/ {
             set $upstream_server dondothat-server:8080;
             proxy_pass http://$upstream_server;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,7 +4,13 @@ events {
 
 http {
     resolver 127.0.0.11 valid=30s;
-    
+
+    # WebSocket 연결 타임아웃 설정
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
     server {
         listen 443 ssl;
         server_name 54.208.50.238;
@@ -12,7 +18,30 @@ http {
         ssl_certificate /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;
         ssl_protocols TLSv1.2 TLSv1.3;
-        
+
+        # WebSocket 전용 location
+        location /api/ws {
+            set $upstream_server dondothat-server:8080;
+            proxy_pass http://$upstream_server;
+
+            # WebSocket 필수 헤더들
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+
+            # 기본 프록시 헤더들
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket 타임아웃 설정
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+            proxy_connect_timeout 86400s;
+        }
+
+        # 일반 HTTP 요청 처리
         location / {
             set $upstream_server dondothat-server:8080;
             proxy_pass http://$upstream_server;


### PR DESCRIPTION
## 📌 관련 이슈
closed #156 

## ✨ 내용
현재 WebSocket 통신은 `ws`를 사용하는데, `https`를 사용하는 프론트와 통신하기 위해서는 `wss`를 사용해야 함
nginx 설정에 WebSocket 관련 설정을 추가함

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
