### PR TITLE
[FIX] 챌린지 실패 시 결제 내역 조회 쿼리 수정

### DIFF
--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -146,7 +146,7 @@
         ORDER BY end_date DESC, start_date DESC
     </select>
 
-    <!-- 챌린지 실패시 소비내역 조회 (최근 7일간) -->
+    <!-- 챌린지 실패시 소비내역 조회 -->
     <select id="getFailExpenditures" resultType="org.bbagisix.challenge.dto.ChallengeFailDTO">
         SELECT
             e.amount,

--- a/src/main/resources/mappers/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mappers/challenge/ChallengeMapper.xml
@@ -146,27 +146,18 @@
         ORDER BY end_date DESC, start_date DESC
     </select>
 
-    <!-- 챌린지 실패시 소비내역 조회 -->
+    <!-- 챌린지 실패시 소비내역 조회 (최근 7일간) -->
     <select id="getFailExpenditures" resultType="org.bbagisix.challenge.dto.ChallengeFailDTO">
         SELECT
             e.amount,
             e.description,
             e.expenditure_date as expenditureDate
         FROM expenditure e
-                 JOIN (
-            SELECT user_id, MAX(end_date) as latest_end_date
-            FROM user_challenge
-            WHERE user_id = #{userId}
-            GROUP BY user_id
-        ) uc ON e.user_id = uc.user_id
-            AND DATE(e.expenditure_date) = DATE(uc.latest_end_date)
+        JOIN challenge c ON c.challenge_id = #{challengeId}
         WHERE e.user_id = #{userId}
-          AND e.category_id = #{challengeId}
-          AND EXISTS (
-            SELECT 1
-            FROM user_challenge uc2
-            WHERE uc2.user_id = #{userId}
-              AND uc2.challenge_id = #{challengeId}
-        )
+          AND e.category_id = c.category_id
+          AND e.expenditure_date >= DATE_SUB(NOW(), INTERVAL 1 DAY)
+        ORDER BY e.expenditure_date DESC
+        LIMIT 10
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
closed #217 

## ✨ 내용
- 챌린지 실패 페이지에서 실패 원인이 된 결제 내역이 조회되지 않음
- 기존 쿼리가 너무 복잡하고 제한적인 조건으로 인해 빈 결과 반환 (마지막 날짜만 조회하는 쿼리였음)

- `getFailExpenditures` 쿼리 단순화 및 최적화
- 복잡한 서브쿼리와 날짜 제약 조건 제거
- 최근 1일간의 해당 카테고리 내역 조회로 변경