### PR TITLE
[BUG] 채팅 로직 수정

### DIFF
--- a/src/main/java/org/bbagisix/chat/service/ChatService.java
+++ b/src/main/java/org/bbagisix/chat/service/ChatService.java
@@ -153,9 +153,9 @@ public class ChatService {
 		}
 
 		try {
-			log.warn("❌ userId가 null입니다");  // 추가
+			log.info("📊 사용자 활성 챌린지 조회: userId={}", userId);
 			UserChallengeInfoDTO challengeInfo = chatMapper.selectUserActiveChallengeInfo(userId);
-			log.info("📊 DB 조회 결과: {}", challengeInfo);  // 추가
+			log.info("📊 DB 조회 결과: {}", challengeInfo);
 
 			if (challengeInfo == null) {
 				// 참여 중인 챌린지가 없는 경우

--- a/src/main/resources/mappers/chat/ChatMapper.xml
+++ b/src/main/resources/mappers/chat/ChatMapper.xml
@@ -143,7 +143,6 @@
         FROM user_challenge uc
                  JOIN challenge c ON uc.challenge_id = c.challenge_id
         WHERE uc.user_id = #{userId}
-          AND uc.status = 'ongoing'
         ORDER BY uc.start_date DESC LIMIT 1
     </select>
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #220 

## ✨ 내용
1. MyBatis 쿼리 수정 (src/main/resources/mappers/chat/ChatMapper.xml)

  - selectUserActiveChallengeInfo 쿼리에서 AND uc.status = 'ongoing' 조건 제거
  - 사용자의 가장 최근 챌린지 상태를 모든 status에 대해 조회하도록 변경
  - 이를 통해 failed/completed/closed 상태도 정확히 반환

    변경 전:
     WHERE uc.user_id = #{userId}
     AND uc.status = 'ongoing'
     ORDER BY uc.start_date DESC LIMIT 1

    변경 후:
     WHERE uc.user_id = #{userId}
     ORDER BY uc.start_date DESC LIMIT 1

  2. ChatService 로그 개선 (src/main/java/org/bbagisix/chat/service/ChatService.java)

  - getUserChallengeStatus 메서드의 로그 메시지 수정
  - 디버깅을 위한 명확한 로그 추가